### PR TITLE
Fix compilation error caused by invalid comment

### DIFF
--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -75,7 +75,7 @@ and kwargs = (string * tvalue) list
    And it's important to know that the filtered target is the LAST argument of filter function.
    For example, consider following expansion of "x" with filter function "foo" (with no keyword arguments)
    
-   {{x|foo(10,20)}}
+   {{ x|foo(10,20) }}
 
    The filter function "foo" takes 3 arguments, and internally, this is evaluated like this.
 


### PR DESCRIPTION
A fragment `{x|` in the comment will be interpreted as a beginning
of a string literal in OCaml 4.02, that is not expected.
