### PR TITLE
Allow for expressions in object lookup

### DIFF
--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -33,10 +33,22 @@ let rec value_of_expr env ctx = function
   | SetExpr(expr_list) -> Tset (List.map (value_of_expr env ctx) expr_list)
   | DotExpr(IdentExpr(name), prop) -> jg_obj_lookup_by_name ctx name prop
   | DotExpr(left, prop) -> jg_obj_lookup ctx (value_of_expr env ctx left) prop
+  | BracketExpr(left, expr) ->
+    (match value_of_expr env ctx expr with
+     | Tstr prop -> jg_obj_lookup ctx (value_of_expr env ctx left) prop
+     | _ -> Tnull)
   | TestOpExpr(IdentExpr(name), IdentExpr("defined")) -> jg_test_defined ctx name
   | TestOpExpr(IdentExpr(name), IdentExpr("undefined")) -> jg_test_undefined ctx name
   | TestOpExpr(DotExpr(IdentExpr(name), prop), IdentExpr("defined")) -> jg_test_obj_defined ctx name prop
   | TestOpExpr(DotExpr(IdentExpr(name), prop), IdentExpr("undefined")) -> jg_test_obj_undefined ctx name prop
+  | TestOpExpr(BracketExpr(IdentExpr(name), expr), IdentExpr("defined")) ->
+    (match value_of_expr env ctx expr with
+     | Tstr prop -> jg_test_obj_defined ctx name prop
+     | _ -> Tbool false)
+  | TestOpExpr(BracketExpr(IdentExpr(name), expr), IdentExpr("undefined")) ->
+    (match value_of_expr env ctx expr with
+     | Tstr prop -> jg_test_obj_undefined ctx name prop
+     | _ -> Tbool true)
   | TestOpExpr(IdentExpr(name), IdentExpr("none")) -> jg_test_none ctx name
   | TestOpExpr(IdentExpr(name), IdentExpr("escaped")) -> jg_test_escaped ctx
   | TestOpExpr(IdentExpr(name), IdentExpr("upper")) -> jg_test_upper (jg_get_value ctx name) []

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -31,12 +31,12 @@ let rec value_of_expr env ctx = function
   | InOpExpr(left, right) -> jg_inop (value_of_expr env ctx left) (value_of_expr env ctx right)
   | ListExpr(expr_list) -> Tlist (List.map (value_of_expr env ctx) expr_list)
   | SetExpr(expr_list) -> Tset (List.map (value_of_expr env ctx) expr_list)
-  | DotExpr(IdentExpr(name), IdentExpr(prop)) -> jg_obj_lookup_by_name ctx name prop
-  | DotExpr(left, IdentExpr(prop)) -> jg_obj_lookup ctx (value_of_expr env ctx left) prop
+  | DotExpr(IdentExpr(name), prop) -> jg_obj_lookup_by_name ctx name prop
+  | DotExpr(left, prop) -> jg_obj_lookup ctx (value_of_expr env ctx left) prop
   | TestOpExpr(IdentExpr(name), IdentExpr("defined")) -> jg_test_defined ctx name
   | TestOpExpr(IdentExpr(name), IdentExpr("undefined")) -> jg_test_undefined ctx name
-  | TestOpExpr(DotExpr(IdentExpr(name), IdentExpr(prop)), IdentExpr("defined")) -> jg_test_obj_defined ctx name prop
-  | TestOpExpr(DotExpr(IdentExpr(name), IdentExpr(prop)), IdentExpr("undefined")) -> jg_test_obj_undefined ctx name prop
+  | TestOpExpr(DotExpr(IdentExpr(name), prop), IdentExpr("defined")) -> jg_test_obj_defined ctx name prop
+  | TestOpExpr(DotExpr(IdentExpr(name), prop), IdentExpr("undefined")) -> jg_test_obj_undefined ctx name prop
   | TestOpExpr(IdentExpr(name), IdentExpr("none")) -> jg_test_none ctx name
   | TestOpExpr(IdentExpr(name), IdentExpr("escaped")) -> jg_test_escaped ctx
   | TestOpExpr(IdentExpr(name), IdentExpr("upper")) -> jg_test_upper (jg_get_value ctx name) []
@@ -76,7 +76,7 @@ let rec value_of_expr env ctx = function
 
 and apply_name_of = function
   | IdentExpr(name) -> name
-  | DotExpr(IdentExpr(name), IdentExpr(prop)) -> spf "%s.%s" name prop
+  | DotExpr(IdentExpr(name), prop) -> spf "%s.%s" name prop
   | ApplyExpr(expr, args) -> apply_name_of expr
   | _ -> "<lambda>"
 

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -200,8 +200,8 @@ expr:
 | FALSE { pel "false"; LiteralExpr (Tbool false) }
 | STRING { pel "string"; LiteralExpr (Tstr $1) }
 | NULL { pel "null"; LiteralExpr Tnull }
-| expr DOT ident { pel "dot_lookup"; DotExpr($1, $3) }
-| expr LBRACKET STRING RBRACKET { pel "dot_lookup(dict)"; DotExpr($1, IdentExpr($3)) }
+| expr DOT ident { pel "dot_lookup"; DotExpr($1, ident_name($3)) }
+| expr LBRACKET STRING RBRACKET { pel "dot_lookup(dict)"; DotExpr($1, $3) }
 | NOT expr { pel "not expr"; NotOpExpr($2) }
 | MINUS expr %prec UMINUS { pel "negative"; NegativeOpExpr($2) }
 | LBRACKET expr_list RBRACKET { pel "list expr"; ListExpr($2) }

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -201,7 +201,7 @@ expr:
 | STRING { pel "string"; LiteralExpr (Tstr $1) }
 | NULL { pel "null"; LiteralExpr Tnull }
 | expr DOT ident { pel "dot_lookup"; DotExpr($1, ident_name($3)) }
-| expr LBRACKET STRING RBRACKET { pel "dot_lookup(dict)"; DotExpr($1, $3) }
+| expr LBRACKET expr RBRACKET { pel "bracket_lookup"; BracketExpr($1, $3) }
 | NOT expr { pel "not expr"; NotOpExpr($2) }
 | MINUS expr %prec UMINUS { pel "negative"; NegativeOpExpr($2) }
 | LBRACKET expr_list RBRACKET { pel "list expr"; ListExpr($2) }

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -108,6 +108,7 @@ let dump_expr = function
   | LtEqOpExpr(_,_) -> "LtEqOpExpr"
   | GtEqOpExpr(_,_) -> "GtEqOpExpr"
   | DotExpr(_,_) -> "DotExpr"
+  | BracketExpr(_,_) -> "BracketExpr"
   | ListExpr(_) -> "ListExpr"
   | SetExpr(_) -> "SetExpr"
   | ObjExpr(_) -> "ObjExpr"

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -81,6 +81,7 @@ and expression =
   | LtEqOpExpr of expression * expression
   | GtEqOpExpr of expression * expression
   | DotExpr of expression * string
+  | BracketExpr of expression * expression
   | ApplyExpr of expression * arguments
   | ListExpr of expression list
   | SetExpr of expression list

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -80,7 +80,7 @@ and expression =
   | GtOpExpr of expression * expression
   | LtEqOpExpr of expression * expression
   | GtEqOpExpr of expression * expression
-  | DotExpr of expression * expression
+  | DotExpr of expression * string
   | ApplyExpr of expression * arguments
   | ListExpr of expression list
   | SetExpr of expression list

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -141,6 +141,7 @@ and expression =
   | LtEqOpExpr of expression * expression
   | GtEqOpExpr of expression * expression
   | DotExpr of expression * string
+  | BracketExpr of expression * expression
   | ApplyExpr of expression * arguments
   | ListExpr of expression list
   | SetExpr of expression list

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -140,7 +140,7 @@ and expression =
   | GtOpExpr of expression * expression
   | LtEqOpExpr of expression * expression
   | GtEqOpExpr of expression * expression
-  | DotExpr of expression * expression
+  | DotExpr of expression * string
   | ApplyExpr of expression * arguments
   | ListExpr of expression list
   | SetExpr of expression list

--- a/tests/test_output.ml
+++ b/tests/test_output.ml
@@ -130,7 +130,13 @@ let test_defined test_ctxt =
   assert_interp ~test_ctxt
     "{% set obj = {age:10, name:'taro'} %}\
      {{ obj['name'] is defined }}"
-    "true"
+    "true";
+
+  assert_interp ~test_ctxt
+    "{% set ids = {Taro: 'taro'} %}\
+     {% set ages = {taro: 10} %}\
+     {{ ages[ids['Taro']] is defined }}"
+    "true";
 ;;
 
 let from_file test_ctxt file_name =


### PR DESCRIPTION
This enables you to write `obj[expr]` where `expr` should evaluate to a `Tstr`.  I find this to be useful, and you can also do it with Jinja2.