### PR TITLE
Add a bytecode-only target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all:
 	cd src && make
 
+byte:
+	cd src && make byte
+
 test:
 	cd tests && make run
 

--- a/opam
+++ b/opam
@@ -6,7 +6,8 @@ bug-reports: "https://github.com/tategakibunko/jingoo/issues"
 dev-repo: "git@github.com:tategakibunko/jingoo.git"
 license: "BSD-3"
 build: [
-  [make]
+  [make] {ocaml-native}
+  [make "byte"] {!ocaml-native}
 ]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "jingoo"]

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,11 @@ LIB_CMO:=$(foreach s,$(LIB_ML), $(basename $(notdir $(s))).cmo)
 LIB_CMX:=$(foreach s,$(LIB_ML), $(basename $(notdir $(s))).cmx)
 LIB_CMI:=$(foreach s,$(LIB_ML), $(basename $(notdir $(s))).cmi)
 
-all: jg_parser.ml jg_lexer.ml jingoo.cma jingoo.cmxa jingoo_mt.cmx jingoo_mt.cmo compiler
+all: byte opt
+
+byte: jg_parser.ml jg_lexer.ml jingoo.cma jingoo_mt.cmo
+
+opt: jingoo.cmxa jingoo_mt.cmx compiler
 
 jg_parser.ml: $(MLY)
 	$(YAC) $(MLY)
@@ -46,7 +50,7 @@ compiler: jingoo.cmxa jg_cmdline.ml
 	$(OCAMLOPT) -o $@ -linkpkg -package $(PKG) jingoo.cmxa jg_cmdline.ml
 
 install: all
-	ocamlfind install jingoo *.a *.cma *.cmxa *.cmi jingoo_mt.cm[ox] jingoo_mt.o jg_types.mli jg_template.mli jg_stub.mli META
+	ocamlfind install jingoo *.a *.cma *.cmi jingoo_mt.cmo jingoo_mt.o jg_types.mli jg_template.mli jg_stub.mli META -optional *.cmxa jingoo_mt.cmx
 
 uninstall:
 	ocamlfind remove jingoo


### PR DESCRIPTION
Hi,

First, thanks for this great library! We use it a lot @cryptosense to generate all kinds of HTML reports.

Some environments do not support native compilation. This adds a "make byte" target that only builds a bytecode library. This target is automatically selected by opam when the variable `ocaml-native` is false.

Thanks!