### PR TITLE
use $(MAKE) instead of hard-coded make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,25 @@
 all:
-	cd src && make
+	$(MAKE) -C src
 
 byte:
 	cd src && make byte
 
 test:
-	cd tests && make run
+	$(MAKE) -C tests run
 
-reinstall:
-	cd src && make uninstall && make install
+reinstall: uninstall install
 
 install:
-	cd src && make install
+	$(MAKE) -C src install
 
 uninstall:
-	cd src && make uninstall
+	$(MAKE) -C src uninstall
 
 clean:
-	cd src && make clean
-	cd tests && make clean
+	$(MAKE) -C src clean
+	$(MAKE) -C tests clean
 
 rebuild:
-	cd src && make rebuild
+	$(MAKE) -C src rebuild
 
 .PHONY: all test reinstall install uninstall reinstall clean rebuild

--- a/example/Makefile
+++ b/example/Makefile
@@ -25,6 +25,6 @@ clean:
 	rm -f *.cmi *.cmo *.cmx *.o *.cmxs
 	rm -f $(TARGET)
 
-rebuild:
-	make clean
-	make all
+rebuild: clean all
+
+.PHONY: rebuild clean all

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,15 +55,13 @@ install: all
 uninstall:
 	ocamlfind remove jingoo
 
-reinstall:
-	make uninstall
-	make install
+reinstall: uninstall install
 
 clean:
 	rm -f *.cmi *.cmo *.cmx *.cma *.a *.cmxa *.o *.annot *.byte
 	rm -f jg_lexer.ml jg_parser.ml jg_parser.mli
 	rm -f $(COMPILER)
 
-rebuild:
-	make clean
-	make all
+rebuild: clean all
+
+.PHONY: rebuild clean reinstall uninstall install compiler

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,7 +8,6 @@ CMPL:=ocamlfind ocamlopt -g
 
 all: test
 
-.PHONY:test
 test: $(SRCS)
 	$(CMPL) -o $@ -package $(PKGS) -linkpkg -I ../src ../src/jingoo.cmxa $(SRCS)
 
@@ -22,3 +21,4 @@ rebuild:
 run: test
 	./test
 
+.PHONY: run rebuild clean all


### PR DESCRIPTION
For compatiblity with systems that do not ship with GNU make by default, including *BSDs and OS X.

Closes #16.