### PR TITLE
Install .cmx files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -50,7 +50,7 @@ compiler: jingoo.cmxa jg_cmdline.ml
 	$(OCAMLOPT) -o $@ -linkpkg -package $(PKG) jingoo.cmxa jg_cmdline.ml
 
 install: all
-	ocamlfind install jingoo *.a *.cma *.cmi jingoo_mt.cmo jingoo_mt.o jg_types.mli jg_template.mli jg_stub.mli META -optional *.cmxa jingoo_mt.cmx
+	ocamlfind install jingoo *.a *.cma *.cmi *.cmx jingoo_mt.cmo jingoo_mt.o jg_types.mli jg_template.mli jg_stub.mli META -optional *.cmxa jingoo_mt.cmx
 
 uninstall:
 	ocamlfind remove jingoo


### PR DESCRIPTION
Since OCaml 4.03, the compiler can use .cmx files to perform cross-module optimization. A side effect of this is that if these files are not installed and the corresponding .cmi file is not compiled with `-opaque`, the following warning is printed:

```
Warning 58: no cmx file was found in path for module Jg_template, and its interface was not compiled with -opaque
```

This fixes this warning and makes it possible to get extra optimizations.

Thanks! ✨ 