### PR TITLE
Add support for iterating over Tobj and Thash data type passed from OCaml

### DIFF
--- a/example/cheatsheet.tmpl
+++ b/example/cheatsheet.tmpl
@@ -87,17 +87,17 @@ for test
   {% endfor %}
 </ul>
 
-</ul>
+<ul>
   {% for name, value in obj %}
   <li>{{ name }} - {{ value }}</li>
   {% endfor %}
-<ul>
-
 </ul>
+
+<ul>
   {% for name, value in hash %}
   <li>{{ name }} - {{ value }}</li>
   {% endfor %}
-<ul>
+</ul>
 
 obj test
 =========

--- a/example/cheatsheet.tmpl
+++ b/example/cheatsheet.tmpl
@@ -87,6 +87,18 @@ for test
   {% endfor %}
 </ul>
 
+</ul>
+  {% for name, value in obj %}
+  <li>{{ name }} - {{ value }}</li>
+  {% endfor %}
+<ul>
+
+</ul>
+  {% for name, value in hash %}
+  <li>{{ name }} - {{ value }}</li>
+  {% endfor %}
+<ul>
+
 obj test
 =========
 

--- a/example/test_data.ml
+++ b/example/test_data.ml
@@ -1,5 +1,11 @@
 open Jg_types
 
+let build_ht () =
+  let ht = Hashtbl.create 10 in
+  Hashtbl.add ht "a" (Tint 1);
+  Hashtbl.add ht "b" (Tint 2);
+  Thash ht
+
 let models = [
   ("msg", Tstr "hello world");
   ("list1", Tlist [Tint 1]);
@@ -15,5 +21,6 @@ let models = [
     Tobj [("name", Tstr "bob"); ("age", Tint 20)];
     Tobj [("name", Tstr "ken"); ("age", Tint 25)];
   ]);
+  ("hash", build_ht ());
 ] 
 ;;

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -263,8 +263,11 @@ let jg_iter ctx iterator f iterable =
     match iterable with
       | Tlist lst -> lst
       | Tset lst -> lst
-      | Tobj lst -> List.map (fun v -> Tset [ box_string @@ fst v; snd v ]) lst
-      | _ -> failwith "jg_iter:not iterable object" in
+      | Tobj lst -> List.map (fun (n, v) -> Tset [ box_string n; v ]) lst
+      | Thash hash -> Hashtbl.fold (fun k v a -> (k,v)::a) hash []
+        |> List.map (fun (n, v) -> Tset [ box_string n; v ])
+      | _ -> failwith "jg_iter:not iterable object"
+  in
   let len = List.length lst in
   let rec iter ctx i = function
     | [] -> ctx

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -250,7 +250,7 @@ let jg_obj_lookup ctx obj prop_name =
   match obj with
     | Tobj(alist) -> (try List.assoc prop_name alist with Not_found -> Tnull)
     | Thash(hash) -> (try Hashtbl.find hash prop_name with Not_found -> Tnull)
-    | _ -> failwith "jg_obj_lookup:not object"
+    | _ -> failwith ("jg_obj_lookup:not object when looking for '"  ^ prop_name ^ "'")
 
 let jg_obj_lookup_by_name ctx obj_name prop_name =
   match jg_get_value ctx obj_name with
@@ -263,6 +263,7 @@ let jg_iter ctx iterator f iterable =
     match iterable with
       | Tlist lst -> lst
       | Tset lst -> lst
+      | Tobj lst -> List.map (fun v -> Tset [ box_string @@ fst v; snd v ]) lst
       | _ -> failwith "jg_iter:not iterable object" in
   let len = List.length lst in
   let rec iter ctx i = function

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -264,8 +264,8 @@ let jg_iter ctx iterator f iterable =
       | Tlist lst -> lst
       | Tset lst -> lst
       | Tobj lst -> List.map (fun (n, v) -> Tset [ box_string n; v ]) lst
-      | Thash hash -> Hashtbl.fold (fun k v a -> (k,v)::a) hash []
-        |> List.map (fun (n, v) -> Tset [ box_string n; v ])
+      | Thash hash -> List.map (fun (n, v) -> Tset [ box_string n; v ]) @@
+          Hashtbl.fold (fun k v a -> (k,v)::a) hash []
       | _ -> failwith "jg_iter:not iterable object"
   in
   let len = List.length lst in


### PR DESCRIPTION
The patch adds support for iterating over Tobj and Thash data types passed via the OCaml API