### PR TITLE
Adapt to OCaml's 4.06.0 where -safe-string is the default.

### DIFF
--- a/src/jg_utils.ml
+++ b/src/jg_utils.ml
@@ -110,9 +110,7 @@ let read_file_as_string filename =
   let file = open_in_bin filename in
   let size = in_channel_length file in
   try
-    let buf = String.create size in (* for compatibility of OCaml <= 3 *)
-    (* let buf = Bytes.create size in *)
-    really_input file buf 0 size;
+    let buf = really_input_string file size in
     close_in file;
     buf
   with e ->


### PR DESCRIPTION
Note that this implies that ocaml < 4.02 may not be supported without
some hack as `really_input_string` was introduced in 4.02.0.