### PR TITLE
 Added Tvolatile contructor + few fixes

### DIFF
--- a/example/cheatsheet.tmpl
+++ b/example/cheatsheet.tmpl
@@ -406,9 +406,21 @@ hoge == "ok" and hage == "ng"
 [PR#34] [PR#35] Laziness
 ========================
 {% if lazy.next.next.next.next.prev.cur == 3 %}
-   Laziness if awesome :)
+   Laziness is awesome :)
 {% else %}
-   Laziness if broken :(
+   Laziness is broken :(
+{% endif %}
+
+{# end of 'main' block #}
+{% endblock %}
+
+
+[PR#36] Volatile
+========================
+{% if volatile %}
+   Volatile works fine :)
+{% else %}
+   Volatile is broken :(
 {% endif %}
 
 {# end of 'main' block #}

--- a/example/test_data.ml
+++ b/example/test_data.ml
@@ -12,6 +12,8 @@ let rec lazy_model n =
                             | "next" -> lazy_model (n + 1)
                             | _ -> raise Not_found ) ) )
 
+let volatile = ref false
+
 let models = [
   ("msg", Tstr "hello world");
   ("list1", Tlist [Tint 1]);
@@ -29,6 +31,9 @@ let models = [
   ]);
   ("hash1", build_ht ());
   ("array1", Tarray [| Tstr "this"; Tstr "is"; Tstr "from"; Tstr "array" |]);
-  ("lazy", lazy_model 0)
-] 
-;;
+  ("lazy", lazy_model 0);
+  ("volatile", Tvolatile (fun () -> !volatile))
+]
+
+let _ = volatile := true
+

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -27,8 +27,10 @@ let rec value_of_expr env ctx = function
   | PowerOpExpr(left, right) -> jg_power (value_of_expr env ctx left) (value_of_expr env ctx right)
   | DivOpExpr(left, right) -> jg_div (value_of_expr env ctx left) (value_of_expr env ctx right)
   | ModOpExpr(left, right) -> jg_mod (value_of_expr env ctx left) (value_of_expr env ctx right)
-  | AndOpExpr(left, right) -> jg_and (value_of_expr env ctx left) (value_of_expr env ctx right)
-  | OrOpExpr(left, right) -> jg_or (value_of_expr env ctx left) (value_of_expr env ctx right)
+  | AndOpExpr(left, right) ->
+    Tbool (jg_is_true (value_of_expr env ctx left) && jg_is_true (value_of_expr env ctx right))
+  | OrOpExpr(left, right) ->
+    Tbool (jg_is_true (value_of_expr env ctx left) || jg_is_true (value_of_expr env ctx right))
   | EqEqOpExpr(left, right) -> jg_eq_eq (value_of_expr env ctx left) (value_of_expr env ctx right)
   | NotEqOpExpr(left, right) -> jg_not_eq (value_of_expr env ctx left) (value_of_expr env ctx right)
   | LtOpExpr(left, right) -> jg_lt (value_of_expr env ctx left) (value_of_expr env ctx right)

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -41,6 +41,7 @@ and tvalue =
   | Tfun of (args -> kwargs -> tvalue)
   | Tarray of tvalue array
   | Tlazy of tvalue Lazy.t
+  | Tvolatile of (unit -> tvalue)
 and args = tvalue list
 and kwargs = (string * tvalue) list
 

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -68,6 +68,7 @@ and tvalue =
   | Tfun of (args -> kwargs -> tvalue)
   | Tarray of tvalue array
   | Tlazy of tvalue Lazy.t
+  | Tvolatile of (unit -> tvalue)
 and args = tvalue list
 and kwargs = (string * tvalue) list
 (**

--- a/tests/test_output.ml
+++ b/tests/test_output.ml
@@ -38,7 +38,13 @@ let test_if test_ctxt =
   assert_interp ~test_ctxt source ~models:["x", Tint 2] "two";
   assert_interp ~test_ctxt source ~models:["x", Tint 4] "three";
 ;;
-  
+
+let test_and_or test_ctxt =
+  assert_interp ~test_ctxt "{% if undefined and undefined.foo %}foo{% endif %}" "";
+  assert_interp ~test_ctxt
+    ~models:[ ("foo", Tbool true) ; ("bar", Tvolatile (fun () -> assert false)) ]
+    "{% if foo or bar %}foo{% endif %}" "foo"
+
 let test_for test_ctxt =
   assert_interp ~test_ctxt
     "{% for i in range(1,3) %}{{i}}{% endfor %}"
@@ -199,6 +205,7 @@ let suite = "runtime test" >::: [
   "test_expand_safe" >:: test_expand_safe;
   "test_expand_filter" >:: test_expand_filter;
   "test_if" >:: test_if;
+  "test_and_or" >:: test_and_or;
   "test_for" >:: test_for;
   "test_loop_index" >:: test_loop_index;
   "test_loop_index0" >:: test_loop_index0;


### PR DESCRIPTION
First, I can split this into two PR if you want, but if you like the whole stuff it is simpler to make only one.

`Tvolatile` use case is to access some `mutable` field of a structure, or a `ref` that could evolve between the time the data are built and the time the template is evaluated.

Also, I fixed the order of evaluation of `and` and `or` expressions.
`jg_and (value_of_expr env ctx left) (value_of_expr env ctx right)` make both `left` and `right` sides evaluated. Also, OCaml evaluate function's arguments from right to left), so the right side of the test would be evaluated first here. This was not my main concern, but it could lead to unexpected behavior if some side effect is involved in `left` and `right`.

The main problem was that `{% if foo && foo.bar %}` would raise an exception if `foo` is undefined while `foo.bar` should actually never be evaluated.