### PR TITLE
Optimize some operations on strings

### DIFF
--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -93,7 +93,7 @@
 }
 
 let blank = [ ' ' '\t' ]
-let ident_first_char = [ 'A'-'Z' 'a'-'z' ]
+let ident_first_char = [ 'A'-'Z' 'a'-'z' '_' ]
 let ident_char =  [ 'A'-'Z' 'a'-'z' '_' '0'-'9' ]
 let int_literal = ['0'-'9'] ['0'-'9']*
 let float_literal = ['0'-'9']+('.' ['0'-'9']*)? (['e' 'E'] ['+' '-']? ['0'-'9']+)?

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -422,15 +422,15 @@ let jg_plus left right =
   match left, right with
     | Tint x1, Tint x2 -> Tint(x1+x2)
     | Tint x1, Tfloat x2 -> Tfloat(float_of_int x1+.x2)
-    | Tint x1, Tstr x2 -> Tstr (String.concat "" [string_of_int x1; x2])
+    | Tint x1, Tstr x2 -> Tstr (string_of_int x1 ^ x2)
 
     | Tfloat x1, Tfloat x2 -> Tfloat(x1+.x2)
     | Tfloat x1, Tint x2 -> Tfloat(x1+.float_of_int x2)
-    | Tfloat x1, Tstr x2 -> Tstr (String.concat "" [string_of_float x1; x2])
+    | Tfloat x1, Tstr x2 -> Tstr (string_of_float x1 ^ x2)
 
-    | Tstr x1, Tstr x2 -> Tstr (String.concat "" [x1; x2])
-    | Tstr x1, Tint x2 -> Tstr (String.concat "" [x1; string_of_int x2])
-    | Tstr x1, Tfloat x2 -> Tstr (String.concat "" [x1; string_of_float x2])
+    | Tstr x1, Tstr x2 -> Tstr (x1 ^ x2)
+    | Tstr x1, Tint x2 -> Tstr (x1 ^ string_of_int x2)
+    | Tstr x1, Tfloat x2 -> Tstr (x1 ^ string_of_float x2)
 
     | _, _ -> failwith "jg_plus:type error"
 

--- a/src/jg_utils.ml
+++ b/src/jg_utils.ml
@@ -95,17 +95,17 @@ let chomp str =
 
 let is_lower str =
   try
-    ignore @@ Pcre.exec ~rex:(Pcre.regexp "[A-Z]+") str;
-    false
+    String.iter (function 'A'..'Z' -> raise Not_found | _ -> ()) str ;
+    true
   with
-      Not_found -> true
+    Not_found -> false
 
 let is_upper str =
   try
-    ignore @@ Pcre.exec ~rex:(Pcre.regexp "[a-z]+") str;
-    false
+    String.iter (function 'a'..'z' -> raise Not_found | _ -> ()) str ;
+    true
   with
-      Not_found -> true
+    Not_found -> false
 
 let rec take ?pad n lst =
   match n, lst, pad with

--- a/src/jg_utils.ml
+++ b/src/jg_utils.ml
@@ -54,10 +54,7 @@ let escape_html str =
   String.iter (fun c ->
       incr strlen ;
       match c with
-      | '&' -> buflen := !buflen + 5 (* "&amp;" *)
-      | '"' -> buflen := !buflen + 6 (* "&quot;" *)
-      | '<' -> buflen := !buflen + 4 (* "&lt;" *)
-      | '>' -> buflen := !buflen + 4 (* "&gt;" *)
+      | '&' | '"' | '<' | '>' -> buflen := !buflen + 5 (* "&#xx;" *)
       | _ -> incr buflen
     ) str ;
   if !buflen = !strlen then str
@@ -75,16 +72,17 @@ let escape_html str =
       end
     in
     let add_string s =
-      let len = String.length s in
-      Bytes.blit_string s 0 buf !j len ;
-      j := !j + len
+      copy () ;
+      Bytes.blit_string s 0 buf !j 5 ;
+      j := !j + 5 ;
+      incr i
     in
     String.iter (fun c ->
         match c with
-        | '&' -> copy () ; add_string "&amp;" ; incr i
-        | '"' -> copy () ; add_string "&quot;" ; incr i
-        | '<' -> copy () ; add_string "&lt;" ; incr i
-        | '>' -> copy () ; add_string "&gt;" ; incr i
+        | '&' -> add_string "&#38;"
+        | '"' -> add_string "&#34;"
+        | '<' -> add_string "&#60;"
+        | '>' -> add_string "&#62;"
         | _ -> incr len
       ) str ;
     copy () ;

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -207,7 +207,8 @@ let test_slice ctx =
 let test_wordcount ctx =
   assert_equal (jg_wordcount (Tstr "hoge hige hage") kwargs) (Tint 3);
   assert_equal (jg_wordcount (Tstr "hoge") kwargs) (Tint 1);
-  assert_equal (jg_wordcount (Tstr "") kwargs) (Tint 0)
+  assert_equal (jg_wordcount (Tstr "") kwargs) (Tint 0);
+  assert_equal (jg_wordcount (Tstr "日　本　語") kwargs) (Tint 3)
 ;;
 
 let test_round ctx =

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -12,7 +12,11 @@ let tval_equal t1 t2 =
     | _ -> failwith "tval_equal:invalid op"
 
 let test_escape ctx =
-  assert_equal (Tstr "&lt;script&gt;") (jg_escape_html (Tstr "<script>") kwargs)
+  assert_equal (Tstr "&lt;script&gt;") (jg_escape_html (Tstr "<script>") kwargs);
+  assert_equal (Tstr "&quot;&quot;") (jg_escape_html (Tstr "\"\"") kwargs);
+  assert_equal
+    (Tstr "Lo&amp;rem&gt;\n I&lt;ps&quot;um")
+    (jg_escape_html (Tstr "Lo&rem>\n I<ps\"um") kwargs);
 ;;
 
 let test_string_of_tvalue ctx =

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -12,10 +12,10 @@ let tval_equal t1 t2 =
     | _ -> failwith "tval_equal:invalid op"
 
 let test_escape ctx =
-  assert_equal (Tstr "&lt;script&gt;") (jg_escape_html (Tstr "<script>") kwargs);
-  assert_equal (Tstr "&quot;&quot;") (jg_escape_html (Tstr "\"\"") kwargs);
+  assert_equal (Tstr "&#60;script&#62;") (jg_escape_html (Tstr "<script>") kwargs);
+  assert_equal (Tstr "&#34;&#34;") (jg_escape_html (Tstr "\"\"") kwargs);
   assert_equal
-    (Tstr "Lo&amp;rem&gt;\n I&lt;ps&quot;um")
+    (Tstr "Lo&#38;rem&#62;\n I&#60;ps&#34;um")
     (jg_escape_html (Tstr "Lo&rem>\n I<ps\"um") kwargs);
 ;;
 


### PR DESCRIPTION
As I am a little bit concerned by rendering speed, I would like to be able to avoid most of `Pcre` calls. And mostly the ones that are likely to occur often.

I may have changed since 2011 (also, it may not) but according to https://mirage.io/blog/ocaml-regexp, Pcre is not fast at all.

Most of the `Pcre` could be replaced quite easily by vanilla OCaml without adding to much lines/complexity to the code.

`jg_urlize` is probably the more tricky function to re-implement without a regexp lib, because I did not really looked at what this regexp is supposed to done.

Any comment?

Note to myself jinja2 implementation: https://github.com/pallets/jinja/blob/f2e9280f5e5a4e753edb33415f9a16e56b20562a/jinja2/utils.py#L189