### PR TITLE
Added basic namespace support.

### DIFF
--- a/example/cheatsheet.tmpl
+++ b/example/cheatsheet.tmpl
@@ -19,6 +19,12 @@ this is footer!
 {# main content #}
 {% block main %}
 
+{% set error = namespace (count=0) -%}
+
+{% macro assert (b) -%}
+  {% if not b %}{% set error.count = error.count + 1 %}{% endif %}
+{%- endmacro %}
+
 include test
 ============
 
@@ -55,6 +61,13 @@ set test
 set hoge = "ok"
 {% set hoge = "ok" %}
 now hoge = {{ hoge }}
+
+set foo, bar = ("foo", "bar")
+{% set foo, bar = ("foo", "bar") %}
+
+{{ assert (foo == 'foo' and bar == 'bar') }}
+foo -> {{ foo }}
+bar -> {{ bar }}
 
 if test
 =======
@@ -406,12 +419,12 @@ hoge == "ok" and hage == "ng"
 ========================
 {% for item in array1 %}{{item}} {% endfor %}
 
-
 [PR#34] [PR#35] Laziness
 ========================
 {% if lazy.next.next.next.next.prev.cur == 3 %}
    Laziness is awesome :)
 {% else %}
+  {{ assert (false) }}
    Laziness is broken :(
 {% endif %}
 
@@ -420,7 +433,32 @@ hoge == "ok" and hage == "ng"
 {% if volatile %}
    Volatile works fine :)
 {% else %}
+  {{ assert (false) }}
    Volatile is broken :(
+{% endif %}
+
+[PR#41] Basic namespace support
+========================
+{% set ns = namespace (foo=0, bar='bar') -%}
+
+{%- for i in [1,2,3] -%}
+  {%- set ns.foo = ns.foo + i -%}
+  {%- set ns.bar = ns.bar + i -%}
+{%- endfor -%}
+
+{%- if ns.foo == 6 and ns.bar == 'bar123' %}
+   Namespace works :)
+{%- else %}
+  {{ assert (false) }}
+   Namespace is broken :(
+{%- endif %}
+
+========================
+
+{% if error.count != 0 %}
+  {{ error.count }} error{% if error.count > 1 %}s{% endif %} detected
+{% else %}
+  No errors detected!
 {% endif %}
 
 {# end of 'main' block #}

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -112,7 +112,17 @@ stmts:
 stmt:
   expr { pel "expand expr"; ExpandStatement($1) }
 | error { raise @@ SyntaxError "expand stmt error" }
-| SET ident_list EQ expr { pel "set sts"; SetStatement(SetExpr($2), $4) }
+| SET ident DOT ident EQ expr { pel "set"; SetStatement (DotExpr ($2, ident_name $4), $6) }
+| SET ident_list EQ expr {
+      pel "set";
+      match $2, $4 with
+      | [ n ], ApplyExpr (IdentExpr "namespace", init) ->
+         let extract_assign = function
+           | KeywordExpr (n, v) -> (ident_name n, v)
+           | _ -> assert false in
+         NamespaceStatement (ident_name n, List.map extract_assign init)
+      | _ -> pel "set sts"; SetStatement(SetExpr($2), $4)
+    }
 | SET error { raise @@ SyntaxError "set" }
 | EXTENDS STRING { pel "extends sts"; ExtendsStatement($2) }
 | EXTENDS error { raise @@ SyntaxError "extends" }

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -206,7 +206,9 @@ let rec jg_get_value ctx name =
     | frame :: rest ->
       (try jg_force (Hashtbl.find frame name)
        with Not_found -> get_value name rest)
-    | [] -> Tnull in
+    | [] ->
+      (try Thash (Hashtbl.find ctx.namespace_table name)
+       with Not_found -> Tnull) in
   get_value name ctx.frame_stack
 
 let jg_get_func ctx name =
@@ -1077,6 +1079,7 @@ let jg_init_context ?(models=[]) output env =
   ];
   { frame_stack = [model_frame; top_frame];
     macro_table = Hashtbl.create 10;
+    namespace_table = Hashtbl.create 10;
     active_filters = [];
     output
   }

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -19,6 +19,7 @@ type environment = {
 and context = {
   frame_stack : frame list;
   macro_table : (string, macro) Hashtbl.t;
+  namespace_table : (string, frame) Hashtbl.t;
   active_filters : string list;
   output : string -> unit
 }
@@ -65,6 +66,7 @@ and statement =
   | CallStatement of expression * arguments * arguments * ast
   | WithStatement of expression list * ast
   | AutoEscapeStatement of expression * ast
+  | NamespaceStatement of string * (string * expression) list
 
 and expression =
     IdentExpr of string

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -58,6 +58,7 @@ type environment = {
 and context = {
   frame_stack : frame list;
   macro_table : (string, macro) Hashtbl.t;
+  namespace_table : (string, frame) Hashtbl.t;
   active_filters : string list;
   output : string -> unit;
 }
@@ -137,6 +138,7 @@ and statement =
   | CallStatement of expression * arguments * arguments * ast
   | WithStatement of expression list * ast
   | AutoEscapeStatement of expression * ast
+  | NamespaceStatement of string * (string * expression) list
 
 and expression =
     IdentExpr of string


### PR DESCRIPTION
As it is said in http://jinja.pocoo.org/docs/2.10/templates/#assignments

```
As of version 2.10 more complex use cases can be handled using namespace objects which allow propagating of changes across scopes:

{% set ns = namespace(found=false) %}
{% for item in items %}
    {% if item.check_something() %}
        {% set ns.found = true %}
    {% endif %}
    * {{ item.title }}
{% endfor %}
Found item having something: {{ ns.found }}

Note hat the obj.attr notation in the set tag is only allowed for namespace objects; attempting to assign an attribute on any other object will raise an exception.

New in version 2.10: Added support for namespace objects
```

NB: My implementation *may* be bugged because it does not allow you to access variables from outside of your current `{% block %}` section. I am not sure if it really is a bug, it depends if one should be able to access these variables or not. I do not know how to do it (but I did not actually looked at it, so this behavior change may be trivial).