### PR TITLE
Add support for empty else and a test for it

### DIFF
--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -144,6 +144,7 @@ stmt:
 | CALL opt_args ident LPAREN expr_list RPAREN stmts ENDCALL { pel "call sts"; CallStatement($3, $2, $5, $7) }
 | CALL error { raise @@ SyntaxError "call error" }
 | IF if_chain else_part ENDIF { pel "if sts"; IfStatement($2, $3) }
+| IF if_chain ELSE ENDIF { pel "if sts empty else"; IfStatement($2, []) }
 | IF error { raise @@ SyntaxError "if" }
 | FOR ident_list IN expr stmts ENDFOR { pel "for sts"; ForStatement(SetExpr($2), $4, $5) }
 | FOR expr IN expr stmts ENDFOR { pel "for sts"; ForStatement($2, $4, $5) }

--- a/tests/test_output.ml
+++ b/tests/test_output.ml
@@ -43,6 +43,14 @@ let test_if test_ctxt =
   assert_interp ~test_ctxt source ~models:["x", Tint 4] "three";
 ;;
 
+let test_if_empty_else test_ctxt =
+  let source =
+    "{% if x == 1 %}one{% else %}{% endif %}"
+  in
+  assert_interp ~test_ctxt source ~models:["x", Tint 1] "one";
+  assert_interp ~test_ctxt source ~models:["x", Tint 2] "";
+;;
+
 let test_and_or test_ctxt =
   assert_interp ~test_ctxt "{% if undefined and undefined.foo %}foo{% endif %}" "";
   assert_interp ~test_ctxt
@@ -214,6 +222,7 @@ let suite = "runtime test" >::: [
   "test_expand_safe" >:: test_expand_safe;
   "test_expand_filter" >:: test_expand_filter;
   "test_if" >:: test_if;
+  "test_if_empty_else" >:: test_if_empty_else;
   "test_and_or" >:: test_and_or;
   "test_for" >:: test_for;
   "test_loop_index" >:: test_loop_index;


### PR DESCRIPTION
`{% if something %}aaa{% else %}{% endif %}` used to work in 1.2.17, but broke in 1.2.18. This fix restores backwards compatibility.