### PR TITLE
Added .gitattribute to provide .jingoo syntax highlight on github.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.jingoo linguist-language=html+jinja

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -166,7 +166,6 @@ if_chain:
 else_part:
 /* empty */ { pel "else part empty"; [] }
 | ELSE stmts { pel "else part"; $2 }
-| ELSE error { raise @@ SyntaxError "else_part" }
 ;
 
 as_part:


### PR DESCRIPTION
Note: syntax highlighting will not work until .jingoo file changes, but I tried to push some dummy changes and it worked.