### PR TITLE
Functions

### DIFF
--- a/example/cheatsheet.jingoo
+++ b/example/cheatsheet.jingoo
@@ -509,6 +509,27 @@ ranks = {% for rank in persons | map(null, attribute="extra.rank") %}{{rank}} {%
 names = {% for name in map(null, persons, attribute="name") %}{{name}} {% endfor %}
 ranks = {% for rank in map(null, persons, attribute="extra.rank") %}{{rank}} {% endfor %}
 
+[PR#59] functions
+========================
+
+{% function incr (i) %}{{i+1}}{% endfunction %}
+incr(1) = {{ incr (1) }} {{ assert (incr (1) == 2) }}
+incr(-1) = {{ incr (-1) }} {{ assert (incr (-1) == 0) }}
+
+{% function lt1 (i) %}{{ i < 1 }}{% endfunction %}
+lt1(1) = {{ lt1 (1) }} {{ assert (not lt1 (1)) }}
+lt1(-1) = {{ lt1 (-1) }} {{ assert (lt1 (-1)) }}
+
+{% function obj (x, y) %}{{ {a:x,b:y} }}{% endfunction %}
+{a:'x',b:'y'} = {{ {a:'x',b:'y'} }}
+obj(1,2) = {{ obj(1,2) }} {{ assert ( (obj(1,2)).a == 1 && (obj(1,2)).b == 2) }}
+(obj('a','b')).a = {{ (obj('a','b')).a }} {{ assert ( (obj('a','b')).a == 'a') }}
+(obj('a','b')).b = {{ (obj('a','b')).b }} {{ assert ( (obj('a','b')).b == 'b') }}
+
+{% function inv (reverse=false, x, y) %}{% if reverse %}{{ {a:y,b:x} }}{% else %}{{ {a:x,b:y} }}{% endif %}{% endfunction %}
+(inv('a','b')).a = {{ (inv('a','b')).a }} {{ assert ( (inv('a','b')).a == 'a') }}
+(inv(reverse=true,'a','b')).a = {{ (inv(reverse=true,'a','b')).a }} {{ assert ( (inv(reverse=true,'a','b')).a == 'b') }}
+
 [PR#60] Empty if/elif/else parts
 ========================
 

--- a/example/cheatsheet.jingoo
+++ b/example/cheatsheet.jingoo
@@ -460,7 +460,7 @@ hoge == "ok" and hage == "ng"
 ========================
 
 <ul>
-{%- for group in persons_to_group | groupby ('gender') %}
+{%- for group in persons_to_group | groupby (attribute='gender', null) %}
     <li>
       Gender: {{ group.grouper }}
       <ul>
@@ -502,7 +502,6 @@ max of [10, 20, 30] = {{max(list)}}
 [PR#53] map
 ========================
 
-{# map(filter, list|array, attribute=?), now filter is not supported, so we set it as null. #}
 names = {% for name in persons | map(null, attribute="name") %}{{name}} {% endfor %}
 ranks = {% for rank in persons | map(null, attribute="extra.rank") %}{{rank}} {% endfor %}
 
@@ -529,6 +528,13 @@ obj(1,2) = {{ obj(1,2) }} {{ assert ( (obj(1,2)).a == 1 && (obj(1,2)).b == 2) }}
 {% function inv (reverse=false, x, y) %}{% if reverse %}{{ {a:y,b:x} }}{% else %}{{ {a:x,b:y} }}{% endif %}{% endfunction %}
 (inv('a','b')).a = {{ (inv('a','b')).a }} {{ assert ( (inv('a','b')).a == 'a') }}
 (inv(reverse=true,'a','b')).a = {{ (inv(reverse=true,'a','b')).a }} {{ assert ( (inv(reverse=true,'a','b')).a == 'b') }}
+
+{% function add_val (val=0, x) -%}
+  {{ [ x, (x + val) ] }}
+{%- endfunction %}
+{% for x in [-1,0,1,2] | map (add_val, val=-2) -%}
+  add_val(val=-2,{{x[0]}}) = {{x[1]}} {{ assert (lt1(x[1])) }}
+{% endfor %}
 
 [PR#60] Empty if/elif/else parts
 ========================

--- a/src/jg_ast_mapper.ml
+++ b/src/jg_ast_mapper.ml
@@ -49,6 +49,11 @@ and statement self stmt : statement = match stmt with
                    , List.map (self.expression self) args
                    , self.ast self ast)
 
+  | FunctionStatement (e, args, ast) ->
+    FunctionStatement ( self.expression self e
+                      , List.map (self.expression self) args
+                      , self.ast self ast)
+
   | FilterStatement (e, ast) ->
     FilterStatement (self.expression self e, self.ast self ast)
 

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -186,6 +186,8 @@ rule main = parse
   | "endfilter" as s { token_or_str (s, ENDFILTER) main lexbuf }
   | "macro" as s { token_or_str (s, MACRO) main lexbuf }
   | "endmacro" as s { token_or_str (s, ENDMACRO) main lexbuf }
+  | "function" as s { token_or_str (s, FUNCTION) main lexbuf }
+  | "endfunction" as s { token_or_str (s, ENDFUNCTION) main lexbuf }
   | "call" as s { token_or_str (s, CALL) main lexbuf }
   | "endcall" as s { token_or_str (s, ENDCALL) main lexbuf }
   | "import" as s { token_or_str (s, IMPORT) main lexbuf }

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -28,6 +28,8 @@
 %token INCLUDE
 %token MACRO
 %token ENDMACRO
+%token FUNCTION
+%token ENDFUNCTION
 %token BLOCK
 %token ENDBLOCK
 %token FILTER
@@ -141,6 +143,8 @@ stmt:
 | FROM error{ raise @@ SyntaxError "from import error" }
 | MACRO ident LPAREN expr_list RPAREN stmts ENDMACRO { pel "macro sts"; MacroStatement($2, $4, $6) }
 | MACRO error { raise @@ SyntaxError "macro" }
+| FUNCTION ident LPAREN expr_list RPAREN stmts ENDFUNCTION { pel "function sts"; FunctionStatement($2, $4, $6) }
+| FUNCTION error { raise @@ SyntaxError "function" }
 | CALL opt_args ident LPAREN expr_list RPAREN stmts ENDCALL { pel "call sts"; CallStatement($3, $2, $5, $7) }
 | CALL error { raise @@ SyntaxError "call error" }
 | IF if_chain { pel "if sts"; IfStatement($2) }

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -239,7 +239,7 @@ let jg_obj_lookup_by_name ctx obj_name prop_name =
 let jg_nth value i =
   match value with
   | Tarray a -> a.(i)
-  | Tlist l -> List.nth l i
+  | Tset l | Tlist l -> List.nth l i
   | _ -> failwith_type_error_1 "jg_nth" value
 
 let jg_get_func ctx name =

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -286,13 +286,15 @@ let jg_apply_filters ?(autoescape=true) ?(safe=false) ctx text filters =
   if safe || not autoescape then text else jg_escape_html text
 
 let jg_output ?(autoescape=true) ?(safe=false) ctx value =
-  (match ctx.active_filters, safe, value with
-    | [], true, Tstr text -> ctx.output text
-    | [], true, value -> ctx.output @@ string_of_tvalue value
-    | _ ->
-      ctx.output @@ string_of_tvalue @@
-	jg_apply_filters ctx value ctx.active_filters ~safe ~autoescape
-  );
+  if ctx.serialize then ctx.output @@ Marshal.to_string value []
+  else
+    begin
+      match ctx.active_filters, safe, value with
+      | [], true, value -> ctx.output @@ string_of_tvalue value
+      | _ ->
+        ctx.output @@ string_of_tvalue @@
+        jg_apply_filters ctx value ctx.active_filters ~safe ~autoescape
+    end ;
   ctx
 
 let jg_obj_lookup_path obj path =
@@ -359,6 +361,20 @@ let jg_iter ctx iterator f iterable =
     List.iteri (fun i itm -> f @@ jg_iter_mk_ctx ctx iterator itm len i) l
   | _ -> ()
 
+let jg_eval_aux env ctx args kwargs macro f =
+  let Macro (arg_names, defaults, code) = macro in
+  let arg_names_len = List.length arg_names in
+  let () =
+    let values = Jg_utils.take arg_names_len args ~pad:Tnull in
+    List.iter2 (jg_set_value ctx) arg_names values in
+  let () =
+    List.iter
+      (fun (name, value) ->
+         let value = try List.assoc name kwargs with Not_found -> value in
+         jg_set_value ctx name value )
+      defaults in
+  f ctx code
+
 let jg_eval_macro ?(caller=false) env ctx macro_name args kwargs macro f =
   let Macro (arg_names, defaults, code) = macro in
   let args_len = List.length args in
@@ -375,16 +391,7 @@ let jg_eval_macro ?(caller=false) env ctx macro_name args kwargs macro f =
       | "caller" -> Tbool caller
       | _ -> raise Not_found
     ) in
-  let () =
-    let values = Jg_utils.take arg_names_len args ~pad:Tnull in
-    List.iter2 (jg_set_value ctx') arg_names values in
-  let () =
-    List.iter
-      (fun (name, value) ->
-         let value = try List.assoc name kwargs with Not_found -> value in
-         jg_set_value ctx' name value )
-      defaults in
-  let _ = f ctx' code in
+  ignore @@ jg_eval_aux env ctx' args kwargs macro f;
   ctx
 
 let jg_test_defined_aux ctx name =
@@ -1211,6 +1218,7 @@ let jg_init_context ?(models=[]) output env =
     macro_table = Hashtbl.create 10;
     namespace_table = Hashtbl.create 10;
     active_filters = [];
+    serialize = false;
     output
   } in
   let rec set_values hash alist = List.iter (fun (n, v) -> Hashtbl.add hash n v) alist in

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -21,6 +21,7 @@ and context = {
   macro_table : (string, macro) Hashtbl.t;
   namespace_table : (string, frame) Hashtbl.t;
   active_filters : string list;
+  serialize: bool;
   output : string -> unit
 }
 
@@ -68,6 +69,7 @@ and statement =
   | AutoEscapeStatement of expression * ast
   | NamespaceStatement of string * (string * expression) list
   | Statements of ast
+  | FunctionStatement of expression * arguments * ast
 
 and expression =
     IdentExpr of string

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -60,6 +60,7 @@ and context = {
   macro_table : (string, macro) Hashtbl.t;
   namespace_table : (string, frame) Hashtbl.t;
   active_filters : string list;
+  serialize: bool;
   output : string -> unit;
 }
 
@@ -92,7 +93,7 @@ and kwargs = (string * tvalue) list
    Arguments of function are defined as "tvalue list".
    And it's important to know that the filtered target is the LAST argument of filter function.
    For example, consider following expansion of "x" with filter function "foo" (with no keyword arguments)
-   
+
    {{ x|foo(10,20) }}
 
    The filter function "foo" takes 3 arguments, and internally, this is evaluated like this.
@@ -108,7 +109,7 @@ and kwargs = (string * tvalue) list
    For example, built-in function "slice" catch two args(slice_length, target_list), and one keyword argument(fill_with).
    and following code slice the list with length 4 and fill 0 for rest space of splitted list.
 
-     slice(4, [1,2,3,4,5], fill_with=0) 
+     slice(4, [1,2,3,4,5], fill_with=0)
 
    It return list of list [[1,2,3,4], [5,0,0,0]], works well.
 
@@ -140,6 +141,7 @@ and statement =
   | AutoEscapeStatement of expression * ast
   | NamespaceStatement of string * (string * expression) list
   | Statements of ast
+  | FunctionStatement of expression * arguments * ast
 
 and expression =
     IdentExpr of string

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -569,6 +569,7 @@ let test_string ctx =
 ;;
 
 let test_groupby ctx =
+  let tmp_ctx = jg_init_context (fun str -> ()) Jg_types.std_env in
   let person ~gender ~first_name ~last_name ~native_lang ~second_lang =
     Tpat (function
     | "gender" -> Tstr gender
@@ -586,8 +587,8 @@ let test_groupby ctx =
     person ~gender:"F" ~first_name:"Hana" ~last_name:"Breton" ~native_lang:"French" ~second_lang:"German";
     person ~gender:"M" ~first_name:"Arlen" ~last_name:"Aubrey" ~native_lang:"English" ~second_lang:"French";
   ] in
-  let groups_by_gender = unbox_list @@ jg_groupby (Tstr "gender") persons in
-  let groups_by_lang_native = unbox_list @@ jg_groupby (Tstr "lang.native") persons in
+  let groups_by_gender = unbox_list @@ jg_groupby tmp_ctx (Tstr "gender") persons in
+  let groups_by_lang_native = unbox_list @@ jg_groupby tmp_ctx (Tstr "lang.native") persons in
   let get_group grouper groups =
     List.find (function
     | Tpat fn -> unbox_string (fn "grouper") = grouper


### PR DESCRIPTION
How it works:
- Parsing and statements evaluations reuse macro mechanism.
- Instead of printing string representation of values, it prints marshalled values in a buffer.
- At the end of function's statements evaluation, it unmarshal the contents of the buffer.
- The whole thing is wrapped into a `Tfun` so it can be used as a regular filter.

`eval` filter has been changed so it can support more than strings (obj, list...).

I needed to add a `serialize` field to context in order to know what to output in `jg_output`.

If you are ok with the implementation, I should probably squash some commits before it is merged.

It has only been tested in `cheatsheet.jingoo`, but I open this PR so we can discuss about it. I'll let you know when I will have it tested more seriously.

The main problem for me is that there is no guarantee that your function will output a single value (i.e. only on `jg_output` call). I expect that having multiple `jg_output` is quite easy with blanks not trimmed, and it should make the program crash. If we need to do something about it, I would suggest to use AST mapper in order to write a step verifying functions.

Fixes https://github.com/tategakibunko/jingoo/issues/52