### PR TITLE
Some enhancements

### DIFF
--- a/src/jg_cmdline.ml
+++ b/src/jg_cmdline.ml
@@ -6,41 +6,52 @@
   License: see LICENSE
 *)
 
-(**
-   jingoo command line compiler
-   -----------------------------
-
-   usage:
-
-     jingoo -template_dirs [template directories] -input [input file]
-
-   example:
-
-     jingoo -template_dirs /path/to/tmpl1,/path/to/tmpl2 -input hello.tmpl > hello.ml
-*)
-
 open Jingoo
 
-let get_template_dirs = function
-  | "" -> []
-  | dirs ->
-    let dirs = Re.replace_string (Re.Pcre.regexp "[\\s\\t]+") ~by:"" dirs in
-    Re.split (Re.Pcre.regexp ",") dirs
+let usage = "jingoo [OPTIONS]"
+let infile = ref ""
+let outfile = ref ""
+let dirs = ref ""
+let dynlink = ref ""
+let models = ref []
 
 let () =
-  let usage = "jingoo -input [input_file]" in
-  let filename = ref "" in
-  let tmplname = ref "" in
-  let dirs = ref "" in
 
   Arg.parse [
-    ("-template_dirs", Arg.String (fun str -> dirs := str), "template dirs(split by comma)");
-    ("-input", Arg.String (fun str -> filename := str), "input filename");
-    ("-interp", Arg.String (fun str -> tmplname := str), "interp template_file with no models");
-  ] ignore usage;
+
+    ("-dynlink", Arg.Set_string dynlink,
+     "FILE1,FILE2,... Load files via dynlink module before running main program.");
+
+    ("-i", Arg.Set_string infile,
+     "input filename. Use - for reading stdin.");
+
+    ("-o", Arg.Set_string outfile,
+     "FILENAME redirect output to FILENAME. Use - for reading stdin.");
+
+    ("-template_dirs", Arg.Set_string dirs,
+     "DIR1,DIR2,... Search these directories when {% include/extend %}");
+
+  ] ignore usage ;
+
+  begin
+    try if !dynlink <> "" then List.iter Dynlink.loadfile (String.split_on_char ',' !dynlink) ;
+    with Dynlink.Error e ->
+      failwith @@ Printf.sprintf "Dynlink error: %s\n%!" (Dynlink.error_message e)
+  end ;
+
+  let outchan =
+    match !outfile with "" | "-" -> stdout | outfile -> open_out outfile
+  in
+
+  let env =
+    { Jg_types.std_env with template_dirs = (String.split_on_char ',' !dirs) }
+  in
 
   try
-    output_string stdout (Jg_template.from_file !tmplname ~models:[])
+    output_string outchan @@
+      match !infile with
+      | "" | "-" -> Jg_template.from_chan stdin ~env ~models:!models
+      | infile -> Jg_template.from_file infile ~env ~models:!models
   with
     | Jg_types.SyntaxError(msg) ->
       Printf.printf "syntax error:%s\n" msg

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -45,7 +45,7 @@ let rec value_of_expr env ctx = function
   | BracketExpr(left, expr) ->
     (match value_of_expr env ctx expr with
      | Tstr prop -> jg_obj_lookup (value_of_expr env ctx left) prop
-     | Tint i -> jg_nth (value_of_expr env ctx left) i
+     | Tint i -> jg_nth_aux (value_of_expr env ctx left) i
      | _ -> Tnull)
   | TestOpExpr(IdentExpr(name), IdentExpr("defined")) -> jg_test_defined ctx name
   | TestOpExpr(IdentExpr(name), IdentExpr("undefined")) -> jg_test_undefined ctx name

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -12,14 +12,12 @@
   type lexer_context = {
     mutable mode : lexer_mode;
     mutable terminator : string option;
-    mutable eof : bool;
     mutable token_required : bool ;
   }
 
   let ctx = {
     mode = `Html;
     terminator = None;
-    eof = false;
     token_required = false
   }
 
@@ -53,7 +51,6 @@
     ctx.token_required <- token_required
 
   let reset_context () =
-    ctx.eof <- false;
     ctx.mode <- `Html;
     ctx.terminator <- None;
     ctx.token_required <- false;
@@ -261,11 +258,7 @@ rule main = parse
       | _ -> fail lexbuf @@ spf "unexpected token:%c" c
   }
   | eof {
-    match ctx.eof with
-      | true -> EOF
-      | _ ->
-	ctx.eof <- true;
-	TEXT (get_buf ())
+      match get_buf () with "" -> EOF | s -> TEXT s
   }
 
 and comment = parse

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -107,7 +107,12 @@ rule main = parse
     add_char '}';
     main lexbuf
   }
-  | "{%" blank+ "raw" blank+ "%}" { raw lexbuf }
+  | ("{%" | (blank | newline)* "{%-")
+       blank* "raw" blank*
+     ("%}" | "-%}" (blank | newline)*) as str {
+    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str;
+    raw lexbuf
+  }
   | ("{%" | (blank | newline)* "{%-") as str {
     String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str;
     if ctx.mode = `Logic then fail lexbuf @@ "Unexpected '{%' token" ;
@@ -271,7 +276,12 @@ and comment = parse
   }
 
 and raw = parse
-  | "{%" blank+ "endraw" blank+ "%}" { TEXT (get_buf()) }
+  | ("{%" | (blank | newline)* "{%-")
+      blank* "endraw" blank*
+    ("%}" | "-%}" (blank | newline)*) as str {
+    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str ;
+    TEXT (get_buf())
+  }
   | _ as c {
     if c = '\n' then Lexing.new_line lexbuf;
     add_char c;

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -289,13 +289,16 @@ and raw = parse
   }
 
 and string_literal terminator = parse
-  | '\\' ['\\' '\"' 'n' 't' 'r'] {
+  | '\\' (_ as c) {
     let chr =
-      match Lexing.lexeme_char lexbuf 1 with
-        | 'n' -> '\n'
-        | 't' -> '\t'
-        | 'r' -> '\r'
-        | c -> c in
+      match c with
+      | '\\' -> '\\'
+      | 'n' -> '\n'
+      | 't' -> '\t'
+      | 'r' -> '\r'
+      | c when c = terminator -> c
+      | c -> fail lexbuf @@ spf "illegal backslash escape:%c" c
+    in
     add_char chr;
     string_literal terminator lexbuf
   }

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -217,14 +217,20 @@ let jg_pop_filter ctx =
 
 (**/**)
 
-(* FIXME: invert n seq *)
-(** [jg_nth seq n] returns the [n]-th value of sequence [seq] *)
-let jg_nth value i =
+(**/**)
+let jg_nth_aux value i =
   match value with
   | Tarray a -> a.(i)
   | Tset l | Tlist l -> List.nth l i
   | Tstr s -> Tstr (String.make 1 @@ String.get s i)
-  | _ -> failwith_type_error_1 "jg_nth" value
+  | _ -> failwith_type_error_1 "jg_nth_aux" value
+(**/**)
+
+(** [jg_nth n seq] returns the [n]-th value of sequence [seq] *)
+let jg_nth ?kwargs:_ i value =
+  match i with
+  | Tint i -> jg_nth_aux value i
+  | _ -> failwith_type_error_1 "jg_nth" i
 
 (** [jg_escape_html x] escape [x] string representation using {!Jg_utils.escape_html} *)
 let jg_escape_html ?kwargs:_ str =
@@ -1307,6 +1313,7 @@ let std_filters = [
   ("map", func_arg2 jg_map);
   ("reject", func_arg2 jg_reject);
   ("filter", func_arg2 jg_filter);
+  ("nth", func_arg2 jg_nth);
 
   ("replace", func_arg3 jg_replace);
   ("substring", func_arg3 jg_substring);

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -691,7 +691,7 @@ let jg_split ?kwargs:_ pat text =
   match pat, text with
     | Tstr pat, Tstr text ->
       let lst =
-	Re.Pcre.split ~rex:(Re.Pcre.regexp pat) text |>
+	Re.Str.split (Re.Str.regexp pat) text |>
 	  List.map (fun str -> Tstr str) in
       Tlist lst
   | _ -> failwith_type_error_2 "jg_split" pat text
@@ -809,7 +809,7 @@ let jg_random ?kwargs:_ lst =
 let jg_replace ?kwargs:_ src dst str =
   match src, dst, str with
     | Tstr src, Tstr dst, Tstr str ->
-      Tstr (Re.replace_string (Re.Pcre.regexp src) ~by:dst str)
+      Tstr (Re.Str.global_replace (Re.Str.regexp src) dst str)
     | _ -> failwith_type_error_3 "jg_replace" src dst str
 
 (** [jg_add a b] is [a + b]. It only support int and float.

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -743,15 +743,13 @@ let jg_abs ?kwargs:_ value =
     | Tint x -> Tint (abs x)
     | _ -> failwith_type_error_1 "jg_abs" value
 
+(** [jg_attr p o]
+    Return the [p] property of object [o]. Support dotted notation. *)
 let jg_attr ?kwargs:_ prop obj =
-  match obj, prop with
-    | Tobj alist, Tstr prop ->
-      (try List.assoc prop alist with Not_found -> Tnull)
-    | Thash htbl, Tstr prop ->
-      (try Hashtbl.find htbl prop with Not_found -> Tnull)
-    | Tpat fn, Tstr prop ->
-      (try fn prop with Not_found -> Tnull)
-    | _ -> Tnull
+  match prop with
+  | Tstr path ->
+    jg_obj_lookup_path obj (string_split_on_char '.' path)
+  | _ -> failwith_type_error_2 "jg_attr" prop obj
 
 (** TODO *)
 (* defaults=[ ("width", Tint 80) ] *)

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -406,7 +406,7 @@ let rec jg_is_true = function
   | Thash x -> Hashtbl.length x > 0
   | Tpat _ -> true
   | Tnull -> false
-  | Tfun _ -> failwith "jg_is_true:type error(function)"
+  | Tfun _ -> true
   | Tarray a -> Array.length a > 0
   | Tlazy fn -> jg_is_true (Lazy.force fn)
   | Tvolatile fn -> jg_is_true (fn ())

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -414,6 +414,12 @@ let rec jg_is_true = function
 let jg_not x =
   Tbool (not (jg_is_true x))
 
+(** [jg_plus a b]
+    The multi-purpose [+] operator.
+    Can add two numbers,
+    concat two strings or a string and a number,
+    append two sequences (list or array).
+  *)
 let jg_plus left right =
   match left, right with
     | Tint x1, Tint x2 -> Tint(x1+x2)
@@ -427,6 +433,11 @@ let jg_plus left right =
     | Tstr x1, Tstr x2 -> Tstr (x1 ^ x2)
     | Tstr x1, Tint x2 -> Tstr (x1 ^ string_of_int x2)
     | Tstr x1, Tfloat x2 -> Tstr (x1 ^ string_of_float x2)
+
+    | Tlist l1, Tlist l2 -> Tlist (List.append l1 l2)
+    | Tarray a1, Tlist l2 -> Tlist (List.append (Array.to_list a1) l2)
+    | Tlist l1, Tarray a2 -> Tlist (List.append l1 (Array.to_list a2))
+    | Tarray a1, Tarray a2 -> Tarray (Array.append a1 a2)
 
     | _, _ -> failwith_type_error_2 "jg_plus" left right
 

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -1198,6 +1198,15 @@ let jg_fold = fun ?kwargs:_ fn acc seq ->
     loop 0 acc
   | _ -> failwith_type_error_3 "jg_fold" fn acc seq
 
+(** [for_all fn seq]
+    checks if all elements of the sequence [seq] satisfy the predicate [fn].
+*)
+let jg_forall = fun ?kwargs:_ fn seq ->
+  match seq, fn with
+  | (Tlist l, Tfun fn) -> Tbool (List.for_all (fun x -> unbox_bool @@ fn [x]) l)
+  | (Tarray l, Tfun fn) -> Tbool (Array.for_all (fun x -> unbox_bool @@ fn [x]) l)
+  | _ -> failwith_type_error_2 "jg_forall" fn seq
+
 (** [jg_test_divisibleby divisor dividend]
     tests if [dividend] is divisible by [divisor]. *)
 let jg_test_divisibleby ?kwargs:_ num target =
@@ -1310,6 +1319,7 @@ let std_filters = [
   ("reject", func_arg2 jg_reject);
   ("filter", func_arg2 jg_filter);
   ("nth", func_arg2 jg_nth);
+  ("forall", func_arg2 jg_forall);
 
   ("replace", func_arg3 jg_replace);
   ("substring", func_arg3 jg_substring);

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -223,6 +223,7 @@ let jg_nth value i =
   match value with
   | Tarray a -> a.(i)
   | Tset l | Tlist l -> List.nth l i
+  | Tstr s -> Tstr (String.make 1 @@ String.get s i)
   | _ -> failwith_type_error_1 "jg_nth" value
 
 (** [jg_escape_html x] escape [x] string representation using {!Jg_utils.escape_html} *)

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -400,9 +400,9 @@ let rec jg_is_true = function
   | Tstr x -> x <> ""
   | Tint x -> x != 0
   | Tfloat x -> (x > epsilon_float) || (x < -. epsilon_float)
-  | Tlist x -> List.length x > 0
-  | Tset x -> List.length x > 0
-  | Tobj x -> List.length x > 0
+  | Tlist x -> x <> []
+  | Tset x -> x <> []
+  | Tobj x -> x <> []
   | Thash x -> Hashtbl.length x > 0
   | Tpat _ -> true
   | Tnull -> false

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -743,7 +743,7 @@ let jg_abs ?kwargs:_ value =
     | Tint x -> Tint (abs x)
     | _ -> failwith_type_error_1 "jg_abs" value
 
-let jg_attr ?kwargs:_ obj prop =
+let jg_attr ?kwargs:_ prop obj =
   match obj, prop with
     | Tobj alist, Tstr prop ->
       (try List.assoc prop alist with Not_found -> Tnull)

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -1168,26 +1168,26 @@ let jg_min ?(kwargs=[]) arg =
   | Tlist (hd :: tl) -> jg_max_min_aux false hd List.iter tl kwargs
   | _ -> failwith_type_error_1 "jg_min" arg
 
-let jg_filter_aux name filter =
+let jg_select_aux name select =
   fun fn seq ->
-    let filtered l = match fn with
-      | Tfun fn -> Tlist (List.filter (fun x -> filter (unbox_bool @@ fn [x])) l)
+    let selected l = match fn with
+      | Tfun fn -> Tlist (List.filter (fun x -> select (unbox_bool @@ fn [x])) l)
       | _ -> failwith_type_error_2 name fn seq
     in
     match seq with
-    | Tarray a -> filtered (Array.to_list a)
-    | Tlist l -> filtered l
+    | Tarray a -> selected (Array.to_list a)
+    | Tlist l -> selected l
     | _ -> failwith_type_error_2 name fn seq
 
 (** [jg_reject fn seq]
     returns the elements of [seq] that {b don't} satify [fn]. *)
 let jg_reject =
-  fun ?kwargs:_ -> jg_filter_aux "jg_reject" not
+  fun ?kwargs:_ -> jg_select_aux "jg_reject" not
 
-(** [jg_filter fn seq]
+(** [jg_select fn seq]
     returns the elements of [seq] that satify [fn]. *)
-let jg_filter =
-  fun ?kwargs:_ -> jg_filter_aux "jg_filter" (fun x -> x)
+let jg_select =
+  fun ?kwargs:_ -> jg_select_aux "jg_select" (fun x -> x)
 
 (** [jg_fold fn acc [b1, ..., bn]] is [fn (... (fn (fn acc b1) b2) ...) bn].
 *)
@@ -1326,7 +1326,7 @@ let std_filters = [
   ("groupby", func_arg2 jg_groupby);
   ("map", func_arg2 jg_map);
   ("reject", func_arg2 jg_reject);
-  ("filter", func_arg2 jg_filter);
+  ("select", func_arg2 jg_select);
   ("nth", func_arg2 jg_nth);
   ("forall", func_arg2 jg_forall);
 

--- a/src/jg_template.ml
+++ b/src/jg_template.ml
@@ -10,7 +10,7 @@ open Jg_types
 (** Internally, interpretted result is outputed to `output:(string -> unit)` interface. *)
 type 'a internal_interp = ?env:Jg_types.environment ->
     ?models:(string * Jg_types.tvalue) list ->
-    output:(string -> unit) ->
+    output:(tvalue -> unit) ->
     ?ctx:Jg_types.context ->
     'a -> unit
 
@@ -23,7 +23,8 @@ type 'a external_interp = ?env:Jg_types.environment ->
 let content (fn : 'a internal_interp) : 'a external_interp =
   fun ?(env=std_env) ?ctx ?(models=[]) (arg:'a) ->
     let buffer = Buffer.create 1024 in
-    let () = fn ~env ~models ~output:(Buffer.add_string buffer) ?ctx arg in
+    let output x = Buffer.add_string buffer (Jg_runtime.string_of_tvalue x) in
+    let () = fn ~env ~models ~output ?ctx arg in
     Buffer.contents buffer
 
 let from_file = content Jg_interp.from_file

--- a/src/jg_template.ml
+++ b/src/jg_template.ml
@@ -27,6 +27,8 @@ let content (fn : 'a internal_interp) : 'a external_interp =
     let () = fn ~env ~models ~output ?ctx arg in
     Buffer.contents buffer
 
+let from_chan = content (Jg_interp.from_chan ?file_path:None)
+
 let from_file = content Jg_interp.from_file
 
 let from_string = content (Jg_interp.from_string ?file_path:None)

--- a/src/jg_template.mli
+++ b/src/jg_template.mli
@@ -25,6 +25,18 @@ val from_file :
     [("msg", Tstr "hello, world!"); ("count", Tint 100); ]
 *)
 
+val from_chan :
+  ?env:environment ->
+  ?ctx:context ->
+  ?models:(string * tvalue) list ->
+  in_channel ->
+  string
+(** [from_chan env models chan]
+    return result string.
+
+    same as from_file but read template from {!type:Stdlib.in_channel}.
+*)
+
 val from_string :
   ?env:environment ->
   ?ctx:context ->
@@ -38,4 +50,3 @@ val from_string :
 
     nomally, this context is used internal parsing.
 *)
-

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -22,7 +22,7 @@ and context = {
   namespace_table : (string, frame) Hashtbl.t;
   active_filters : string list;
   serialize: bool;
-  output : string -> unit
+  output : tvalue -> unit
 }
 
 and frame = (string, tvalue) Hashtbl.t

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -167,6 +167,9 @@ let unbox_pat = function
   | Tpat pat -> pat
   | _ -> raise @@ Invalid_argument "unbox_pat"
 
+let unbox_lazy = function
+  | Tlazy l -> l
+  | _ -> raise @@ Invalid_argument "unbox_lazy"
 
 let rec func_arg1 (f: ?kwargs:kwargs -> tvalue -> tvalue) =
   Tfun (fun ?(kwargs=[]) args ->

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -47,7 +47,7 @@ and context = {
   namespace_table : (string, frame) Hashtbl.t;
   active_filters : string list;
   serialize: bool;
-  output : string -> unit;
+  output : tvalue -> unit;
 }
 
 and frame = (string, tvalue) Hashtbl.t

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -174,6 +174,7 @@ val unbox_array : tvalue -> tvalue array
 val unbox_obj : tvalue -> (string * tvalue) list
 val unbox_hash : tvalue -> (string, tvalue) Hashtbl.t
 val unbox_pat : tvalue -> (string -> tvalue)
+val unbox_lazy : tvalue -> tvalue Lazy.t
 
 (** {2 Helpers for function writing} *)
 

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -622,18 +622,18 @@ let alice = Tobj [ "name", Tstr "alice" ; "age", Tint 36 ]
 let bob = Tobj [ "name", Tstr "bob" ; "age", Tint 42 ]
 let carol = Tobj [ "name", Tstr "carol" ; "age", Tint 20]
 
-let test_filter_aux jg_filter expected =
+let test_select_aux jg_select expected =
   let persons = Tlist [ alice ; bob ; carol ] in
-  let filter = func_arg1 @@ fun ?kwargs:_ x ->
+  let select = func_arg1 @@ fun ?kwargs:_ x ->
     Tbool (unbox_int (List.assoc "age" (unbox_obj x)) > 30)
   in
-  assert_equal_tvalue expected (jg_filter filter persons)
+  assert_equal_tvalue expected (jg_select select persons)
 
-let test_filter _ctx =
-  test_filter_aux jg_filter (Tlist [ alice ; bob ])
+let test_select _ctx =
+  test_select_aux jg_select (Tlist [ alice ; bob ])
 
 let test_reject _ctx =
-  test_filter_aux jg_reject (Tlist [ carol ])
+  test_select_aux jg_reject (Tlist [ carol ])
 
 let test_fold _ctx =
   let test seq =
@@ -724,7 +724,7 @@ let suite = "runtime test" >::: [
   "test_min_max" >:: test_min_max;
   "test_nth" >:: test_nth;
   "test_map" >:: test_map;
-  "test_filter" >:: test_filter;
+  "test_select" >:: test_select;
   "test_reject" >:: test_reject;
   "test_fold" >:: test_fold;
   "test_forall" >:: test_forall;

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -32,7 +32,6 @@ let test_persons = Tlist [
     ("rank", Tint 5);
   ])];
 ]
-;;
 
 let tval_equal t1 t2 =
   match jg_eq_eq t1 t2 with
@@ -44,8 +43,7 @@ let test_escape _ctx =
   assert_equal_tvalue (Tstr "&#34;&#34;") (jg_escape_html (Tstr "\"\""));
   assert_equal_tvalue
     (Tstr "Lo&#38;rem&#62;\n I&#60;ps&#34;um")
-    (jg_escape_html (Tstr "Lo&rem>\n I<ps\"um"));
-;;
+    (jg_escape_html (Tstr "Lo&rem>\n I<ps\"um"))
 
 let test_string_of_tvalue _ctx =
   assert_equal "a" (string_of_tvalue (Tstr "a"));
@@ -53,15 +51,13 @@ let test_string_of_tvalue _ctx =
   assert_equal "1." (string_of_tvalue (Tfloat 1.0));
   assert_equal "1.2" (string_of_tvalue (Tfloat 1.2));
   assert_equal "<obj>" (string_of_tvalue (Tobj [("name", Tstr "value")]));
-  assert_equal "<list>" (string_of_tvalue (Tlist [Tint 0; Tint 1]));
-;;
+  assert_equal "<list>" (string_of_tvalue (Tlist [Tint 0; Tint 1]))
 
 let test_plus _ctx =
   assert_equal_tvalue (Tint 2) (jg_plus (Tint 1) (Tint 1));
   assert_equal_tvalue (Tint 0) (jg_plus (Tint 1) (Tint (-1)));
   assert_equal_tvalue (Tfloat 1.0) (jg_plus (Tint 0) (Tfloat 1.0));
-  assert_equal_tvalue (Tfloat 2.0) (jg_plus (Tfloat 1.0) (Tfloat 1.0));
-;;
+  assert_equal_tvalue (Tfloat 2.0) (jg_plus (Tfloat 1.0) (Tfloat 1.0))
 
 let test_minus _ctx =
   assert_equal_tvalue (Tint 0) (jg_minus (Tint 1) (Tint 1));
@@ -69,8 +65,7 @@ let test_minus _ctx =
   assert_equal_tvalue (Tint 2) (jg_minus (Tint 1) (Tint (-1)));
   assert_equal_tvalue (Tfloat (-1.0)) (jg_minus (Tint 0) (Tfloat 1.0));
   assert_equal_tvalue (Tfloat 1.0) (jg_minus (Tint 1) (Tfloat 0.0));
-  assert_equal_tvalue (Tfloat 0.0) (jg_minus (Tfloat 1.0) (Tfloat 1.0));
-;;
+  assert_equal_tvalue (Tfloat 0.0) (jg_minus (Tfloat 1.0) (Tfloat 1.0))
 
 let test_list_eq_eq _ctx =
   let lst1 = [Tint 0; Tint 1; Tint 2] in
@@ -79,8 +74,7 @@ let test_list_eq_eq _ctx =
   let lst4 = [Tint 0; Tint 1] in
   assert_equal ~cmp:jg_list_eq_eq lst1 lst2;
   assert_equal (jg_list_eq_eq lst1 lst3) false;
-  assert_equal (jg_list_eq_eq lst1 lst4) false;
-;;
+  assert_equal (jg_list_eq_eq lst1 lst4) false
 
 let test_obj_eq_eq _ctx =
   let obj1 = Tobj [("name", Tstr "john"); ("age", Tint 20)] in
@@ -89,8 +83,7 @@ let test_obj_eq_eq _ctx =
   let obj4 = Tobj [("age", Tint 20); ("name", Tstr "john")] in
   assert_equal ~cmp:jg_obj_eq_eq obj1 obj2 ;
   assert_equal (jg_obj_eq_eq obj1 obj3) false;
-  assert_equal ~cmp:jg_obj_eq_eq obj1 obj4;
-;;
+  assert_equal ~cmp:jg_obj_eq_eq obj1 obj4
 
 let test_batch_list _ctx =
   let ary = jg_range (Tint 0) (Tint 9) in
@@ -102,7 +95,6 @@ let test_batch_list _ctx =
     Tlist [(Tint 8); (Tint 9); (Tstr "x"); (Tstr "x")];
   ] in
   assert_equal_tvalue expect_list batched_list
-;;
 
 (* if fill_with keyword is not given, final row is shrinked by list_length mod slice_count *)
 let test_batch_list2 _ctx =
@@ -115,7 +107,6 @@ let test_batch_list2 _ctx =
     Tlist [(Tint 8); (Tint 9)]
   ] in
   assert_equal_tvalue expect_list batched_list
-;;
 
 let test_batch_array _ctx =
   let ary = jg_range (Tint 0) (Tint 9) in
@@ -126,7 +117,6 @@ let test_batch_array _ctx =
     Tarray [| (Tint 8); (Tint 9); (Tstr "x"); (Tstr "x") |];
   |] in
   assert_equal_tvalue expect_ary batched_ary
-;;
 
 (* if fill_with keyword is not given, final row is shrinked by array_length mod slice_count *)
 let test_batch_array2 _ctx =
@@ -138,46 +128,37 @@ let test_batch_array2 _ctx =
     Tarray [| (Tint 8); (Tint 9) |];
   |] in
   assert_equal_tvalue expect_ary batched_ary
-;;
 
 let test_capitalize _ctx =
   let orig = Tstr "car" in
   let caps = Tstr "Car" in
   assert_equal_tvalue (jg_capitalize orig) caps
-;;
 
 let test_default _ctx =
   assert_equal_tvalue (jg_default (Tstr "hello") Tnull) (Tstr "hello");
   assert_equal_tvalue (jg_default (Tstr "hello") (Tstr "hoge")) (Tstr "hoge")
-;;
 
 let test_length _ctx =
   assert_equal_tvalue (jg_length (Tstr "hoge")) (Tint 4);
   assert_equal_tvalue (jg_length (Tstr "日本語")) (Tint 3);
-  assert_equal_tvalue (jg_length (Tlist [Tint 0; Tint 1])) (Tint 2);
-;;
+  assert_equal_tvalue (jg_length (Tlist [Tint 0; Tint 1])) (Tint 2)
 
 let test_strlen _ctx =
   assert_equal_tvalue (jg_strlen (Tstr "hoge")) (Tint 4);
-  assert_equal_tvalue (jg_strlen (Tstr "日本語")) (Tint 3);
-;;
+  assert_equal_tvalue (jg_strlen (Tstr "日本語")) (Tint 3)
 
 let test_abs _ctx =
   assert_equal_tvalue (jg_abs (Tint (-1))) (Tint 1);
-  assert_equal_tvalue (jg_abs (Tint 1)) (Tint 1);
-;;
+  assert_equal_tvalue (jg_abs (Tint 1)) (Tint 1)
 
 let test_upper _ctx =
   assert_equal_tvalue (jg_upper (Tstr "aaa")) (Tstr "AAA")
-;;
 
 let test_lower _ctx =
   assert_equal_tvalue (jg_lower (Tstr "AAA")) (Tstr "aaa")
-;;
 
 let test_join _ctx =
   assert_equal_tvalue (jg_join (Tstr ",") (Tlist [Tstr "a"; Tstr "b"])) (Tstr "a,b")
-;;
 
 let test_substring _ctx =
   assert_equal_tvalue (jg_substring (Tint 0) (Tint 1) (Tstr "hoge")) (Tstr "h");
@@ -209,18 +190,15 @@ let test_substring _ctx =
   assert_equal_tvalue (jg_substring (Tint 0) (Tint 4) (Tstr "日本語")) (Tstr "日本語");
   assert_equal_tvalue (jg_substring (Tint 1) (Tint 4) (Tstr "日本語")) (Tstr "本語");
   assert_equal_tvalue (jg_substring (Tint 0) (Tint 10) Tnull) (Tstr "")
-;;
 
 let test_truncate _ctx =
   assert_equal_tvalue (jg_truncate (Tint 3) (Tstr "123456789")) (Tstr "123")
-;;
 
 [@@@warning "-3"]
 let test_md5 _ctx =
   let src = "hoge" in
   let md5 = String.lowercase src |> Digest.string |> Digest.to_hex in
   assert_equal_tvalue (jg_md5 (Tstr src)) (Tstr md5)
-;;
 [@@@warning "+3"]
 
 let test_reverse _ctx =
@@ -228,12 +206,10 @@ let test_reverse _ctx =
   let rev = List.rev lst in
   let rev' = jg_reverse (Tlist lst) in
   List.iter2 assert_equal_tvalue rev (unbox_list rev')
-;;
 
 let test_last _ctx =
   let lst = Tlist [Tint 0; Tint 1] in
   assert_equal_tvalue (jg_last lst) (Tint 1)
-;;
 
 let test_replace _ctx =
   let str = Tstr "hoge" in
@@ -241,7 +217,6 @@ let test_replace _ctx =
   let dst = Tstr "hi" in
   let exp = Tstr "hige" in
   assert_equal_tvalue exp (jg_replace src dst str)
-;;
 
 let test_replace_uni _ctx =
   let src = Tstr "日本" in
@@ -249,7 +224,6 @@ let test_replace_uni _ctx =
   let str = Tstr "日本語" in
   let exp= Tstr "英語" in
   assert_equal_tvalue exp (jg_replace src dst str)
-;;
 
 let test_replace_regex _ctx =
   let src = Tstr {|\("[^"]*"\)|} in
@@ -265,7 +239,6 @@ let test_random _ctx =
   let lst'= unbox_list @@ jg_random (Tlist lst) in
   let is_eq_eq = List.for_all2 (=) lst lst' in
   assert_equal is_eq_eq false
-;;
 
 let test_slice _ctx =
   let lst = Tlist [Tint 1; Tint 2; Tint 3; Tint 4; Tint 5] in
@@ -276,47 +249,39 @@ let test_slice _ctx =
   ] in
   let result = jg_slice (Tint 2) lst in
   assert_equal_tvalue expect result
-;;
 
 let test_wordcount _ctx =
   assert_equal_tvalue (jg_wordcount (Tstr "hoge hige hage")) (Tint 3);
   assert_equal_tvalue (jg_wordcount (Tstr "hoge")) (Tint 1);
   assert_equal_tvalue (jg_wordcount (Tstr "")) (Tint 0);
   assert_equal_tvalue (jg_wordcount (Tstr "日　本　語")) (Tint 3)
-;;
 
 let test_trim _ctx =
   assert_equal_tvalue (jg_trim (Tstr " a \n b c ")) (Tstr "a \n b c");
   assert_equal_tvalue (jg_trim (Tstr "　日　本\n　　語　　　")) (Tstr "日　本\n　　語")
-;;
 
 let test_round _ctx =
   assert_equal_tvalue (jg_round (Tstr "floor") (Tfloat 1.5)) (Tfloat 1.0);
   assert_equal_tvalue (jg_round (Tstr "ceil") (Tfloat 1.5)) (Tfloat 2.0)
-;;
 
 let test_range _ctx =
   assert_equal_tvalue (Tarray [|Tint 0; Tint 1; Tint 2|]) (jg_range (Tint 0) (Tint 2));
   assert_equal_tvalue (Tarray [|Tint 2; Tint 1; Tint 0|]) (jg_range (Tint 2) (Tint 0));
   assert_equal_tvalue (Tarray [|Tint 2012; Tint 2011; Tint 2010; Tint 2009; Tint 2008; Tint 2007; Tint 2006|]) (jg_range (Tint 2012) (Tint 2006));
   assert_equal_tvalue (Tarray [|Tstr "a"; Tstr "b"; Tstr "c"; Tstr "d"|]) (jg_range (Tstr "a") (Tstr "d"));
-  assert_equal_tvalue (Tarray [|Tstr "Z"; Tstr "Y"; Tstr "X"|]) (jg_range (Tstr "Z") (Tstr "X"));
-;;
+  assert_equal_tvalue (Tarray [|Tstr "Z"; Tstr "Y"; Tstr "X"|]) (jg_range (Tstr "Z") (Tstr "X"))
 
 let test_sum _ctx =
   assert_equal_tvalue (jg_sum (Tlist [Tint 0; Tint 1; Tint 2])) (Tint 3);
   assert_equal_tvalue (jg_sum (Tlist [Tint 0; Tint 1; Tfloat 2.1])) (Tfloat 3.1)
-;;
 
 let test_int _ctx =
   assert_equal_tvalue (jg_int (Tint 1)) (Tint 1);
   assert_equal_tvalue (jg_int (Tfloat 1.0)) (Tint 1)
-;;
 
 let test_float _ctx =
   assert_equal_tvalue (jg_float (Tfloat 1.0)) (Tfloat 1.0);
   assert_equal_tvalue (jg_float (Tint 1)) (Tfloat 1.0)
-;;
 
 
 let test_times _ctx =
@@ -327,41 +292,35 @@ let test_times _ctx =
   assert_equal_tvalue (jg_times (Tfloat 2.0) (Tfloat 2.0)) (Tfloat 4.0);
   assert_equal_tvalue (jg_times (Tfloat 0.0) (Tfloat 2.0)) (Tfloat 0.0);
   assert_equal_tvalue (jg_times (Tfloat 0.0) (Tint 1)) (Tfloat 0.0)
-;;
 
 let test_power _ctx =
   assert_equal_tvalue (jg_power (Tint 2) (Tint (-1))) (Tfloat 1.0);
   assert_equal_tvalue (jg_power (Tint 2) (Tint 0)) (Tfloat 1.0);
   assert_equal_tvalue (jg_power (Tint 2) (Tint 1)) (Tfloat 2.0);
-  assert_equal_tvalue (jg_power (Tint 2) (Tint 10)) (Tfloat 1024.0);
-;;
+  assert_equal_tvalue (jg_power (Tint 2) (Tint 10)) (Tfloat 1024.0)
 
 let test_div _ctx =
   assert_raises (Failure "jg_div:zero division error") (fun () -> jg_div (Tint 4) (Tint 0));
   assert_raises (Failure "jg_div:zero division error") (fun () -> jg_div (Tint 4) (Tfloat 0.0));
   assert_equal_tvalue (jg_div (Tint 4) (Tint 2)) (Tint 2);
   assert_equal_tvalue (jg_div (Tfloat 4.0) (Tint 2)) (Tfloat 2.0)
-;;
 
 let test_mod _ctx =
   assert_raises (Failure "jg_mod:zero division error") (fun () -> jg_mod (Tint 4) (Tint 0));
   assert_equal_tvalue (jg_mod (Tint 4) (Tint 3)) (Tint 1);
   assert_equal_tvalue (jg_mod (Tint 4) (Tint 1)) (Tint 0)
-;;
 
 let test_and _ctx =
   assert_equal_tvalue (jg_and (Tbool true) (Tbool true)) (Tbool true);
   assert_equal_tvalue (jg_and (Tbool true) (Tbool false)) (Tbool false);
   assert_equal_tvalue (jg_and (Tbool false) (Tbool true)) (Tbool false);
   assert_equal_tvalue (jg_and (Tbool false) (Tbool false)) (Tbool false)
-;;
 
 let test_or _ctx =
   assert_equal_tvalue (jg_or (Tbool true) (Tbool true)) (Tbool true);
   assert_equal_tvalue (jg_or (Tbool true) (Tbool false)) (Tbool true);
   assert_equal_tvalue (jg_or (Tbool false) (Tbool true)) (Tbool true);
   assert_equal_tvalue (jg_or (Tbool false) (Tbool false)) (Tbool false)
-;;
 
 let test_eq_eq _ctx =
   assert_equal_tvalue (jg_eq_eq (Tint 1) (Tint 1)) (Tbool true);
@@ -372,7 +331,6 @@ let test_eq_eq _ctx =
   assert_equal_tvalue (jg_eq_eq (Tstr "日本語") (Tstr "日本語")) (Tbool true);
   assert_equal_tvalue (jg_eq_eq (Tstr "日本語") (Tstr "英語")) (Tbool false);
   assert_equal_tvalue (jg_eq_eq (Tint 0) (Tstr "hoge")) (Tbool false)
-;;
 
 let test_urlize _ctx =
   assert_equal_tvalue
@@ -380,56 +338,47 @@ let test_urlize _ctx =
     (jg_urlize @@ Tstr "go to http://yahoo.co.jp.") ;
   assert_equal_tvalue
     (Tstr "want to go to <a href=\"http://user@foo:8080/bar/?baz=0\">http://user@foo:8080/bar/?baz=0</a>?")
-    (jg_urlize @@ Tstr "want to go to http://user@foo:8080/bar/?baz=0?") ;
-;;
+    (jg_urlize @@ Tstr "want to go to http://user@foo:8080/bar/?baz=0?") 
 
 let test_title _ctx =
   assert_equal_tvalue
     (Tstr "This Is It!")
     (jg_title @@ Tstr "this is it!")
-;;
 
 let test_striptags _ctx =
   assert_equal_tvalue
     (Tstr "hogehoge higehige hagehage")
     (jg_striptags @@ Tstr "<p class='indent'>hogehoge</p> higehige <b>hagehage</b>")
-;;
 
 let test_sort_int_list _ctx =
   assert_equal_tvalue
     (Tlist [Tint 1; Tint 2; Tint 3])
     (jg_sort @@ Tlist [Tint 3; Tint 1; Tint 2])
-;;
 
 let test_sort_int_array _ctx =
   assert_equal_tvalue
     (Tarray [| Tint 1; Tint 2; Tint 3 |])
     (jg_sort @@ Tarray [| Tint 3; Tint 1; Tint 2 |])
-;;
 
 let test_sort_float_list _ctx =
   assert_equal_tvalue
     (Tlist [Tfloat 1.1; Tfloat 2.2; Tfloat 3.0])
     (jg_sort @@ Tlist [Tfloat 3.0; Tfloat 1.1; Tfloat 2.2])
-;;
 
 let test_sort_float_array _ctx =
   assert_equal_tvalue
     (Tarray [| Tfloat 1.1; Tfloat 2.2; Tfloat 3.0 |])
     (jg_sort @@ Tarray [| Tfloat 3.0; Tfloat 1.1; Tfloat 2.2 |])
-;;
 
 let test_sort_string_list _ctx =
   assert_equal_tvalue
     (Tlist [Tstr "aa"; Tstr "baba"; Tstr "caca"])
     (jg_sort @@ Tlist [Tstr "baba"; Tstr "aa"; Tstr "caca"] )
-;;
 
 let test_sort_rev _ctx =
   assert_equal_tvalue
     (Tlist [Tint 3; Tint 2; Tint 1])
     (jg_sort (Tlist [Tint 3; Tint 1; Tint 2]) ~kwargs:[("reverse", Tbool true)])
-;;
 
 let test_sort_attr _ctx =
   let persons = Tlist [
@@ -449,8 +398,7 @@ let test_sort_attr _ctx =
   let reverse_expected = [name_is "ken"; name_is "bob"] in
   let check_person checker person = checker person in
   assert_equal (List.for_all2 check_person forward_expected forward_sorted) true;
-  assert_equal (List.for_all2 check_person reverse_expected reverse_sorted) true;
-;;
+  assert_equal (List.for_all2 check_person reverse_expected reverse_sorted) true
 
 let test_sort_compare _ctx =
   let data = Tlist [
@@ -466,19 +414,16 @@ let test_sort_compare _ctx =
   assert_equal_tvalue
     (Tlist [Tset [Tstr "A"; Tint 0]; Tset [Tstr "b"; Tint 1]; Tset [Tstr "Z"; Tint 2]])
     (jg_sort ~kwargs:[("compare", jg_lower_fst_cmp)] data)
-;;
 
 let test_sort_string_array _ctx =
   assert_equal_tvalue
     (Tarray [| Tstr "aa"; Tstr "baba"; Tstr "caca" |])
     (jg_sort @@ Tarray [| Tstr "baba"; Tstr "aa"; Tstr "caca" |])
-;;
 
 let test_list _ctx =
   assert_equal_tvalue
     (Tlist [Tstr "h"; Tstr "o"; Tstr "g"; Tstr "e"])
     (jg_list @@ Tstr "hoge")
-;;
 
 let test_xmlattr _ctx =
   let obj = Tobj [
@@ -489,7 +434,6 @@ let test_xmlattr _ctx =
   assert_equal_tvalue
     (Tstr "class=\"profile\" id=\"taro\" width=\"300\"")
     (jg_xmlattr obj)
-;;
 
 let test_wordwrap _ctx =
   let text = String.concat " " [
@@ -501,8 +445,7 @@ let test_wordwrap _ctx =
     (jg_wordwrap (Tint 12) (Tbool true) (Tstr text));
   assert_equal_tvalue
     (Tstr "this is it!!\nhoge hogehogehoge")
-    (jg_wordwrap (Tint 12) (Tbool false) (Tstr text));
-;;
+    (jg_wordwrap (Tint 12) (Tbool false) (Tstr text))
 
 let test_sublist _ctx =
   let lst = Tlist [Tint 0; Tint 1; Tint 2; Tint 3] in
@@ -535,36 +478,31 @@ let test_sublist _ctx =
     (jg_sublist (Tint 1) (Tint 3) lst);
   assert_equal_tvalue
     (Tlist [Tint 1; Tint 2; Tint 3])
-    (jg_sublist (Tint 1) (Tint 4) lst);
-;;
+    (jg_sublist (Tint 1) (Tint 4) lst)
 
 let test_fmt_float _ctx =
   let value = Tfloat 3.141592 in
   assert_equal_tvalue (jg_fmt_float (Tint 1) value) (Tfloat 3.1);
   assert_equal_tvalue (jg_fmt_float (Tint 2) value) (Tfloat 3.14);
   assert_equal_tvalue (jg_fmt_float (Tint 3) value) (Tfloat 3.142);
-  assert_equal_tvalue (jg_fmt_float (Tint 4) value) (Tfloat 3.1416);
-;;
+  assert_equal_tvalue (jg_fmt_float (Tint 4) value) (Tfloat 3.1416)
 
 let test_divisibleby _ctx =
   assert_equal_tvalue (jg_test_divisibleby (Tint 2) (Tint 6)) (Tbool true);
   assert_equal_tvalue (jg_test_divisibleby (Tint 5) (Tint 6)) (Tbool false);
-  assert_equal_tvalue (jg_test_divisibleby (Tint 0) (Tint 6)) (Tbool false);
-;;
+  assert_equal_tvalue (jg_test_divisibleby (Tint 0) (Tint 6)) (Tbool false)
 
 let test_even _ctx =
   assert_equal_tvalue (jg_test_even (Tint 0)) (Tbool true);
   assert_equal_tvalue (jg_test_even (Tint 1)) (Tbool false);
   assert_equal_tvalue (jg_test_even (Tint 2)) (Tbool true);
-  assert_equal_tvalue (jg_test_even (Tint 3)) (Tbool false);
-;;
+  assert_equal_tvalue (jg_test_even (Tint 3)) (Tbool false)
 
 let test_odd _ctx =
   assert_equal_tvalue (jg_test_odd (Tint 0)) (Tbool false);
   assert_equal_tvalue (jg_test_odd (Tint 1)) (Tbool true);
   assert_equal_tvalue (jg_test_odd (Tint 2)) (Tbool false);
-  assert_equal_tvalue (jg_test_odd (Tint 3)) (Tbool true);
-;;
+  assert_equal_tvalue (jg_test_odd (Tint 3)) (Tbool true)
 
 let test_iterable _ctx =
   assert_equal_tvalue (jg_test_iterable (Tint 0)) (Tbool false);
@@ -573,29 +511,24 @@ let test_iterable _ctx =
   assert_equal_tvalue (jg_test_iterable (Tobj [])) (Tbool true);
   assert_equal_tvalue (jg_test_iterable (Tlist [])) (Tbool true);
   assert_equal_tvalue (jg_test_iterable (Tset [])) (Tbool true);
-  assert_equal_tvalue (jg_test_iterable Tnull) (Tbool true);
-;;
+  assert_equal_tvalue (jg_test_iterable Tnull) (Tbool true)
 
 let test_is_lower _ctx =
   assert_equal_tvalue (jg_test_lower (Tstr "aaa")) (Tbool true);
   assert_equal_tvalue (jg_test_lower (Tstr "aaA")) (Tbool false)
-;;
 
 let test_is_upper _ctx =
   assert_equal_tvalue (jg_test_upper (Tstr "aaa")) (Tbool false);
-  assert_equal_tvalue (jg_test_upper (Tstr "AAA")) (Tbool true);
-;;
+  assert_equal_tvalue (jg_test_upper (Tstr "AAA")) (Tbool true)
 
 let test_number _ctx =
   assert_equal_tvalue (jg_test_number (Tint 1)) (Tbool true);
   assert_equal_tvalue (jg_test_number (Tfloat 1.0)) (Tbool true);
-  assert_equal_tvalue (jg_test_number (Tstr "1")) (Tbool false);
-;;
+  assert_equal_tvalue (jg_test_number (Tstr "1")) (Tbool false)
 
 let test_string _ctx =
   assert_equal_tvalue (jg_test_string (Tstr "aaa")) (Tbool true);
-  assert_equal_tvalue (jg_test_string (Tint 1)) (Tbool false);
-;;
+  assert_equal_tvalue (jg_test_string (Tint 1)) (Tbool false)
 
 let test_groupby _ctx =
   let person ~gender ~first_name ~last_name ~native_lang ~second_lang =
@@ -655,7 +588,6 @@ let test_groupby _ctx =
   assert_equal (List.for_all2 check_person males_expected males) true;
   assert_equal (List.for_all2 check_person english_speakers_expected english_speakers) true;
   assert_equal (List.for_all2 check_person french_speakers_expected french_speakers) true
-;;
 
 let test_min_max _ctx =
   let numbers = Tlist [Tint 3; Tint 1; Tint 2] in
@@ -667,7 +599,6 @@ let test_min_max _ctx =
   assert_equal_tvalue max_number (Tint 3);
   assert_equal_tvalue (jg_obj_lookup min_person "name") (Tstr "jiro");
   assert_equal_tvalue (jg_obj_lookup max_person "name") (Tstr "hana")
-;;
 
 let test_nth _ctx =
   let list = Tlist [Tint 3; Tint 0; Tint 2] in
@@ -677,8 +608,7 @@ let test_nth _ctx =
   assert_equal_tvalue (Tint 2) (jg_nth (Tint 2) list);
   assert_equal_tvalue (Tint 1) (jg_nth (Tint 0) ary);
   assert_equal_tvalue (Tint 10) (jg_nth (Tint 1) ary);
-  assert_equal_tvalue (Tint 12) (jg_nth (Tint 2) ary);
-;;
+  assert_equal_tvalue (Tint 12) (jg_nth (Tint 2) ary)
 
 let test_map _ctx =
   let names = unbox_list @@ jg_map Tnull test_persons ~kwargs:[("attribute", Tstr "name")] in
@@ -687,7 +617,6 @@ let test_map _ctx =
   let ranks_expected = [Tint 3; Tint 12; Tint 5] in
   assert_equal (List.for_all2 (=) names names_expected) true;
   assert_equal (List.for_all2 (=) ranks ranks_expected) true
-;;
 
 let alice = Tobj [ "name", Tstr "alice" ; "age", Tint 36 ]
 let bob = Tobj [ "name", Tstr "bob" ; "age", Tint 42 ]
@@ -800,4 +729,3 @@ let suite = "runtime test" >::: [
   "test_fold" >:: test_fold;
   "test_forall" >:: test_forall;
 ]
-;;

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -715,6 +715,15 @@ let test_fold _ctx =
   test (Tlist [Tint 0;Tint 1;Tint 2;Tint 3;Tint 4;Tint 5;Tint 6;Tint 7;Tint 8;Tint 9]) ;
   test (Tarray [|Tint 0;Tint 1;Tint 2;Tint 3;Tint 4;Tint 5;Tint 6;Tint 7;Tint 8;Tint 9|])
 
+let test_forall _ctx =
+  let test res seq =
+    assert_equal_tvalue
+      (Tbool res)
+      (jg_forall (func_arg1 @@ fun ?kwargs:_ x -> Tbool (unbox_int x < 10)) seq)
+  in
+  test true (Tlist [Tint 0;Tint 1;Tint 2;Tint 3;Tint 4;Tint 5;Tint 6;Tint 7;Tint 8;Tint 9]) ;
+  test false (Tarray [|Tint 0;Tint 10;Tint 2|])
+
 let suite = "runtime test" >::: [
   "test_escape" >:: test_escape;
   "test_string_of_tvalue" >:: test_string_of_tvalue;
@@ -788,6 +797,7 @@ let suite = "runtime test" >::: [
   "test_map" >:: test_map;
   "test_filter" >:: test_filter;
   "test_reject" >:: test_reject;
-  "test_fold" >:: test_fold
+  "test_fold" >:: test_fold;
+  "test_forall" >:: test_forall;
 ]
 ;;

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -686,7 +686,7 @@ let alice = Tobj [ "name", Tstr "alice" ; "age", Tint 36 ]
 let bob = Tobj [ "name", Tstr "bob" ; "age", Tint 42 ]
 let carol = Tobj [ "name", Tstr "carol" ; "age", Tint 20]
 
-let text_filter_aux jg_filter expected =
+let test_filter_aux jg_filter expected =
   let persons = Tlist [ alice ; bob ; carol ] in
   let filter = func_arg1 @@ fun ?kwargs:_ x ->
     Tbool (unbox_int (List.assoc "age" (unbox_obj x)) > 30)
@@ -694,10 +694,19 @@ let text_filter_aux jg_filter expected =
   assert_equal_tvalue expected (jg_filter filter persons)
 
 let test_filter _ctx =
-  text_filter_aux jg_filter (Tlist [ alice ; bob ])
+  test_filter_aux jg_filter (Tlist [ alice ; bob ])
 
 let test_reject _ctx =
-  text_filter_aux jg_reject (Tlist [ carol ])
+  test_filter_aux jg_reject (Tlist [ carol ])
+
+let test_fold _ctx =
+  let test seq =
+    assert_equal_tvalue
+      (Tint 45)
+      (jg_fold (func_arg2 @@ fun ?kwargs:_ -> jg_add) (Tint 0) seq)
+  in
+  test (Tlist [Tint 0;Tint 1;Tint 2;Tint 3;Tint 4;Tint 5;Tint 6;Tint 7;Tint 8;Tint 9]) ;
+  test (Tarray [|Tint 0;Tint 1;Tint 2;Tint 3;Tint 4;Tint 5;Tint 6;Tint 7;Tint 8;Tint 9|])
 
 let suite = "runtime test" >::: [
   "test_escape" >:: test_escape;
@@ -771,5 +780,6 @@ let suite = "runtime test" >::: [
   "test_map" >:: test_map;
   "test_filter" >:: test_filter;
   "test_reject" >:: test_reject;
+  "test_fold" >:: test_fold
 ]
 ;;

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -247,7 +247,8 @@ let test_slice _ctx =
     Tlist [ Tint 4; Tint 5 ]
   ] in
   let result = jg_slice (Tint 2) lst in
-  assert_equal_tvalue expect result
+  assert_equal_tvalue expect result ;
+  assert_equal_tvalue (Tlist [ Tlist [] ; Tlist [] ]) (jg_slice (Tint 2) (Tlist []))
 
 let test_wordcount _ctx =
   assert_equal_tvalue (jg_wordcount (Tstr "hoge hige hage")) (Tint 3);

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -243,9 +243,8 @@ let test_random _ctx =
 let test_slice _ctx =
   let lst = Tlist [Tint 1; Tint 2; Tint 3; Tint 4; Tint 5] in
   let expect = Tlist [
-    Tlist [Tint 1; Tint 2];
-    Tlist [Tint 3; Tint 4];
-    Tlist [Tint 5];
+    Tlist [ Tint 1; Tint 2; Tint 3];
+    Tlist [ Tint 4; Tint 5 ]
   ] in
   let result = jg_slice (Tint 2) lst in
   assert_equal_tvalue expect result


### PR DESCRIPTION
Summary of these improvements:
- `function` and `eval`: avoid useless buffering and marshaling of values andreturn the last value only. Previous implementation returned the first value only, but this one is more consistent with OCaml, and functions/eval must return only one value anyway.
- Added some filters: `nth` `forall`
- Support array/list appending with the `+` operator. Consistent with the fatch that it already is a multi-purpose operateur used to concat strings.
- Some fixes in the lexer (whitespace control and empty text at the end of parsing) and better error messages.
- Regex: switched from `Re.Pcre` to `Re.Str` so we can use groups in the replacement string.
- Fixed `jg_cmdlin` and include `jingoo` binaray in installation.
- Rework of `attr` filter
- Fixed `jg_slice` (which is not the same as `jg_batch`)
- Renamed `jg_filter` to `jg_select` because "filter" is used too often to speak of a function or of the filter statement.

The rest is mainly cosmetic.