### PR TITLE
Reworked Tfun to provide partial application for all functions.

### DIFF
--- a/example/samples/for.jingoo
+++ b/example/samples/for.jingoo
@@ -1,3 +1,3 @@
 {%- for item in [ 0, 1, 2, 3, 4, 5 ] -%}
-  - {{ item }}: {{ loop.cycle ("even","odd") }}
+  - {{ item }}: {{ loop.cycle (["even","odd"]) }}
 {% endfor -%}

--- a/example/test.ml
+++ b/example/test.ml
@@ -38,16 +38,18 @@ let test jingoo_f =
     else []
   in
   let expected = file_contents html_f in
-  let res = Jg_template.from_file ~models jingoo_f in
-  if res <> expected then begin
+  try
+    match Jg_template.from_file ~models jingoo_f with
+    | res when res = expected -> prerr_endline @@ "--- OK: " ^ jingoo_f
+    | res ->
       prerr_endline @@ "--- Error: " ^ jingoo_f ;
       prerr_endline @@ "--- Expected: " ;
       prerr_endline @@ expected ;
       prerr_endline @@ "--- Got: " ;
       prerr_endline @@ res ;
-      failwith jingoo_f ;
-    end
-  else prerr_endline @@ "--- OK: " ^ jingoo_f
+  with Failure s ->
+    prerr_endline @@ "--- Failure: " ^ jingoo_f ;
+    prerr_endline @@ s
 
 let () =
   let jingoo = ls (Sys.getenv "DOC_SAMPLE_DIR") (fun f -> Filename.extension f = ".jingoo") in

--- a/src/jg_cmdline.ml
+++ b/src/jg_cmdline.ml
@@ -34,7 +34,7 @@ let () =
   ] ignore usage ;
 
   begin
-    try if !dynlink <> "" then List.iter Dynlink.loadfile (String.split_on_char ',' !dynlink) ;
+    try if !dynlink <> "" then List.iter Dynlink.loadfile (Jg_utils.string_split_on_char ',' !dynlink) ;
     with Dynlink.Error e ->
       failwith @@ Printf.sprintf "Dynlink error: %s\n%!" (Dynlink.error_message e)
   end ;
@@ -44,7 +44,7 @@ let () =
   in
 
   let env =
-    { Jg_types.std_env with template_dirs = (String.split_on_char ',' !dirs) }
+    { Jg_types.std_env with template_dirs = (Jg_utils.string_split_on_char ',' !dirs) }
   in
 
   try

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -1190,7 +1190,7 @@ let jg_fold = fun fn acc seq ->
 let jg_forall = fun fn seq ->
   match seq, fn with
   | (Tlist l, Tfun fn) -> Tbool (List.for_all (fun x -> unbox_bool @@ fn x) l)
-  | (Tarray l, Tfun fn) -> Tbool (Array.for_all (fun x -> unbox_bool @@ fn x) l)
+  | (Tarray l, Tfun fn) -> Tbool (Jg_utils.array_for_all (fun x -> unbox_bool @@ fn x) l)
   | _ -> failwith_type_error_2 "jg_forall" fn seq
 
 (** [jg_test_divisibleby divisor dividend]

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -66,7 +66,7 @@ and tvalue =
   | Tpat of (string -> tvalue)
   | Tlist of tvalue list
   | Tset of tvalue list
-  | Tfun of (?kwargs:kwargs -> args -> tvalue)
+  | Tfun of (?kwargs:kwargs -> tvalue -> tvalue)
   | Tarray of tvalue array
   | Tlazy of tvalue Lazy.t
   | Tvolatile of (unit -> tvalue)
@@ -158,7 +158,7 @@ val box_hash : (string, tvalue) Hashtbl.t -> tvalue
 val box_array : tvalue array -> tvalue
 val box_pat : (string -> tvalue) -> tvalue
 val box_lazy : tvalue Lazy.t -> tvalue
-val box_fun : (?kwargs:kwargs -> args -> tvalue) -> tvalue
+val box_fun : (?kwargs:kwargs -> tvalue -> tvalue) -> tvalue
 
 (** {2 Unboxing OCaml values}
     Unboxing operations raise [Invalid_argument] in case of type error.
@@ -175,12 +175,19 @@ val unbox_obj : tvalue -> (string * tvalue) list
 val unbox_hash : tvalue -> (string, tvalue) Hashtbl.t
 val unbox_pat : tvalue -> (string -> tvalue)
 val unbox_lazy : tvalue -> tvalue Lazy.t
+val unbox_fun : tvalue -> (?kwargs:kwargs -> tvalue -> tvalue)
 
 (** {2 Helpers for function writing} *)
 
-val func_arg1 : (?kwargs:kwargs -> tvalue -> tvalue) -> tvalue
-val func_arg2 : (?kwargs:kwargs -> tvalue -> tvalue -> tvalue) -> tvalue
-val func_arg3 : (?kwargs:kwargs -> tvalue -> tvalue -> tvalue -> tvalue) -> tvalue
+val func : (tvalue list -> tvalue) -> int -> tvalue
+val func_1 : ?name:string -> (tvalue -> tvalue) -> tvalue
+val func_2 : ?name:string -> (tvalue -> tvalue -> tvalue) -> tvalue
+val func_3 : ?name:string -> (tvalue -> tvalue -> tvalue -> tvalue) -> tvalue
+
+val func_kw : (?kwargs:kwargs -> tvalue list -> tvalue) -> int -> tvalue
+val func_kw_1 : ?name:string -> (?kwargs:kwargs -> tvalue -> tvalue) -> tvalue
+val func_kw_2 : ?name:string -> (?kwargs:kwargs -> tvalue -> tvalue -> tvalue) -> tvalue
+val func_kw_3 : ?name:string -> (?kwargs:kwargs -> tvalue -> tvalue -> tvalue -> tvalue) -> tvalue
 
 (** {2:notes-tvalue Notes about some data types }
 
@@ -241,3 +248,14 @@ val func_arg3 : (?kwargs:kwargs -> tvalue -> tvalue -> tvalue -> tvalue) -> tval
    Note that kwargs may be defined at any place: [slice(4, fill_with=0, [1,2,3,4,5])].
 
  *)
+
+(**/**)
+(** Function exported for internal usage but not documented *)
+
+val type_string_of_tvalue : tvalue -> string
+val failwith_type_error : string -> (string * tvalue) list -> 'a
+val failwith_type_error_1 : string -> tvalue -> 'a
+val failwith_type_error_2 : string -> tvalue -> tvalue -> 'a
+val failwith_type_error_3 : string -> tvalue -> tvalue -> tvalue -> 'a
+val merge_kwargs : kwargs option -> kwargs option -> kwargs option
+val func_failure : ?name:string -> ?kwargs:kwargs -> tvalue list -> 'a

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -232,10 +232,7 @@ val func_kw_3 : ?name:string -> (?kwargs:kwargs -> tvalue -> tvalue -> tvalue ->
 
    [{{ x | foo (10,20) }}] is equivalent too [{{ foo (10,20,x) }}].
 
-   Also, built-in function are written as functions returning functions until the last parameter
-   is given.
-
-   It allows you to use partial application in you templates [{{ list | map (foo (10,20)) }}]
+   Functions support partial application. e.g. [{{ list | map (foo (10,20)) }}]
 
    There is two kind of arguments: {{:#type-args} unnamed arguments} and {{:#type-kwargs} keyword arguments}.
 

--- a/src/jg_utils.ml
+++ b/src/jg_utils.ml
@@ -277,11 +277,20 @@ let string_split_on_char sep s =
   done;
 sub s 0 !j :: !r
 
-(* Copied from Array module to ensure compatibility with 4.02 *)
+(* Copy of Array.exists which is available in 4.03.0 *)
 let array_exists p a =
   let n = Array.length a in
   let rec loop i =
     if i = n then false
     else if p (Array.unsafe_get a i) then true
     else loop (succ i) in
+  loop 0
+
+(* Copy of Array.for_all which is available in 4.03.0 *)
+let array_for_all p a =
+  let n = Array.length a in
+  let rec loop i =
+    if i = n then true
+    else if p (Array.unsafe_get a i) then loop (succ i)
+    else false in
   loop 0

--- a/tests/test_output.ml
+++ b/tests/test_output.ml
@@ -97,7 +97,7 @@ let test_loop_revindex0 test_ctxt =
 
 let test_loop_cycle test_ctxt =
   assert_interp ~test_ctxt
-    "{% for i in range(1,3) %}{{loop.cycle(\"hoge\",\"hige\",\"hage\")}}\
+    "{% for i in range(1,3) %}{{loop.cycle([\"hoge\",\"hige\",\"hage\"])}}\
     {% endfor %}"
     "hogehigehage"
 ;;

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -409,7 +409,7 @@ let test_sort_compare _ctx =
   let lower_fst_cmp = function
     | [a; b] -> jg_compare (jg_lower (jg_nth_aux a 0)) (jg_lower (jg_nth_aux b 0))
     | _ -> failwith "invalid args" in
-  let jg_lower_fst_cmp = Tfun (fun ?kwargs:_ values -> lower_fst_cmp values) in
+  let jg_lower_fst_cmp = func lower_fst_cmp 2 in
   assert_equal_tvalue (jg_sort data) data;
   assert_equal_tvalue
     (Tlist [Tset [Tstr "A"; Tint 0]; Tset [Tstr "b"; Tint 1]; Tset [Tstr "Z"; Tint 2]])
@@ -624,7 +624,7 @@ let carol = Tobj [ "name", Tstr "carol" ; "age", Tint 20]
 
 let test_select_aux jg_select expected =
   let persons = Tlist [ alice ; bob ; carol ] in
-  let select = func_arg1 @@ fun ?kwargs:_ x ->
+  let select = func_1 @@ fun x ->
     Tbool (unbox_int (List.assoc "age" (unbox_obj x)) > 30)
   in
   assert_equal_tvalue expected (jg_select select persons)
@@ -639,7 +639,7 @@ let test_fold _ctx =
   let test seq =
     assert_equal_tvalue
       (Tint 45)
-      (jg_fold (func_arg2 @@ fun ?kwargs:_ -> jg_add) (Tint 0) seq)
+      (jg_fold (func_2 jg_add) (Tint 0) seq)
   in
   test (Tlist [Tint 0;Tint 1;Tint 2;Tint 3;Tint 4;Tint 5;Tint 6;Tint 7;Tint 8;Tint 9]) ;
   test (Tarray [|Tint 0;Tint 1;Tint 2;Tint 3;Tint 4;Tint 5;Tint 6;Tint 7;Tint 8;Tint 9|])
@@ -648,19 +648,19 @@ let test_fold_str _ctx =
   let str = "abc" in
   assert_equal_tvalue
     (Tstr str)
-    (jg_fold (func_arg2 @@ fun ?kwargs:_ -> jg_plus) (Tstr "") (Tstr str))
+    (jg_fold (func_2 jg_plus) (Tstr "") (Tstr str))
 
 let test_fold_mbstr _ctx =
   let mbstr = "日本語" in
   assert_equal_tvalue
     (Tstr mbstr)
-    (jg_fold (func_arg2 @@ fun ?kwargs:_ -> jg_plus) (Tstr "") (Tstr mbstr))
+    (jg_fold (func_2 jg_plus) (Tstr "") (Tstr mbstr))
 
 let test_forall _ctx =
   let test res seq =
     assert_equal_tvalue
       (Tbool res)
-      (jg_forall (func_arg1 @@ fun ?kwargs:_ x -> Tbool (unbox_int x < 10)) seq)
+      (jg_forall (func_1 @@ fun x -> Tbool (unbox_int x < 10)) seq)
   in
   test true (Tlist [Tint 0;Tint 1;Tint 2;Tint 3;Tint 4;Tint 5;Tint 6;Tint 7;Tint 8;Tint 9]) ;
   test false (Tarray [|Tint 0;Tint 10;Tint 2|])


### PR DESCRIPTION
This is how my idea for making partial application works for any functions, looks like.

I also created helpers to get rid of the unused kwargs in filters definition.

As I said, `loop.cycle ("even", "odd")` would become `loop.cycle (["even", "odd"])` but that's the only breaking change.

Also, if I read the code correctly `(fn ("x"))(arg="foo", "y")` was interpreted as `fn ("x", "y")` and should now be interpreted as `fn ("x", arg="foo", "y")`