### PR TITLE
Improved jg_urlize_regexp for real-world usage.

### DIFF
--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -913,13 +913,15 @@ let jg_urlize_regexp =
   let open Re in
   lazy (compile @@
         group @@
+        let delim op cl = seq [ char op ; rep (compl [ char cl ]) ; char cl ] in
+        let or_paren r = alt [ r ; delim '(' ')' ; delim '[' ']' ; delim '{' '}' ] in
         seq
           [ alt [ str "http" ; str "https" ; str "ftp" ; str "file" ]
           ; str "://"
-          ; rep (alt [ alnum ; set "._-@:~/\\" ])
-          ; opt (seq [ char '?' ; rep (alt [ alnum ; set "._-@:!/\\" ; set "%+=&" ]) ])
-          ; opt (seq [ char '#' ; rep (alt [ alnum ; set "._-" ]) ])
-          ; compl [ set ":.?" ]
+          ; rep1 (or_paren (alt [ alnum ; set "._-@:~/\\" ]))
+          ; opt (seq [ char '?' ; rep (or_paren (alt [ alnum ; set "._-@:!/\\[]" ; set "%+=&" ]) ) ])
+          ; opt (seq [ char '#' ; rep (or_paren (alt [ alnum ; set "._-" ]) ) ])
+          ; or_paren (compl [ set " !\"'(),.:;<>?[]{}" ])
           ])
 
 let jg_urlize text =

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -912,23 +912,34 @@ let jg_range start stop =
 let jg_urlize_regexp =
   let open Re in
   lazy (compile @@
-        group @@
-        let delim op cl = seq [ char op ; rep (compl [ char cl ]) ; char cl ] in
-        let or_paren r = alt [ r ; delim '(' ')' ; delim '[' ']' ; delim '{' '}' ] in
-        seq
-          [ alt [ str "http" ; str "https" ; str "ftp" ; str "file" ]
-          ; str "://"
-          ; rep1 (or_paren (alt [ alnum ; set "._-@:~/\\" ]))
-          ; opt (seq [ char '?' ; rep (or_paren (alt [ alnum ; set "._-@:!/\\[]" ; set "%+=&" ]) ) ])
-          ; opt (seq [ char '#' ; rep (or_paren (alt [ alnum ; set "._-" ]) ) ])
-          ; or_paren (compl [ set " !\"'(),.:;<>?[]{}" ])
-          ])
+        seq [ group (opt (alt [ char '"' ; char '\'' ]) )
+            ; group begin
+                let delim op cl = seq [ char op ; rep (compl [ char cl ]) ; char cl ] in
+                let or_paren r = alt [ r ; delim '(' ')' ; delim '[' ']' ; delim '{' '}' ] in
+                seq
+                  [ alt [ str "http" ; str "https" ; str "ftp" ; str "file" ]
+                  ; str "://"
+                  ; rep1 (or_paren (alt [ alnum ; set "._-@:~/\\" ]))
+                  ; opt (seq [ char '?' ; rep (or_paren (alt [ alnum ; set "._-@:!/\\[]" ; set "%+=&" ]) ) ])
+                  ; opt (seq [ char '#' ; rep (or_paren (alt [ alnum ; set "._-" ]) ) ])
+                  ; or_paren (compl [ set " !\"'(),.:;<>?[]{}" ])
+                  ]
+              end
+            ; group (opt (alt [ char '"' ; char '\'' ]) )
+            ])
 
 let jg_urlize text =
   match text with
     | Tstr text ->
       Tstr (Re.replace (Lazy.force jg_urlize_regexp) text
-              ~f:(fun g -> let h = Re.Group.get g 1 in "<a href=\"" ^ h ^ "\">" ^ h ^ "</a>") )
+              ~f:(fun g ->
+                  let o = Re.Group.get g 1 in
+                  let h = Re.Group.get g 2 in
+                  let c = Re.Group.get g 3 in
+                  match o, h, c with
+                  | "", h, "" -> "<a href=\"" ^ h ^ "\">" ^ h ^ "</a>"
+                  | o, h, c -> o ^ h ^ c
+                ) )
     | _ -> failwith_type_error_1 "jg_urlize" text
 
 let jg_striptags_regexp =

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -335,7 +335,13 @@ let test_urlize _ctx =
     (jg_urlize @@ Tstr "http://gallica.bnf.fr/ark:/12148/bpt6k1249555/f41.image<br>Le 20 juin 1794") ;
   assert_equal_tvalue
     (Tstr "(<a href=\"http://foo.foo/foo(foo)(foo)\">http://foo.foo/foo(foo)(foo)</a>)")
-    (jg_urlize @@ Tstr "(http://foo.foo/foo(foo)(foo))")
+    (jg_urlize @@ Tstr "(http://foo.foo/foo(foo)(foo))") ;
+  assert_equal_tvalue
+    (Tstr "<img src=\"http://foo.foo/foo.jpg\">")
+    (jg_urlize @@ Tstr "<img src=\"http://foo.foo/foo.jpg\">") ;
+  assert_equal_tvalue
+    (Tstr "<a href='http://foo.foo'>foo</a>")
+    (jg_urlize @@ Tstr "<a href='http://foo.foo'>foo</a>")
 
 let test_title _ctx =
   assert_equal_tvalue

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -325,7 +325,17 @@ let test_urlize _ctx =
     (jg_urlize @@ Tstr "go to http://yahoo.co.jp.") ;
   assert_equal_tvalue
     (Tstr "want to go to <a href=\"http://user@foo:8080/bar/?baz=0\">http://user@foo:8080/bar/?baz=0</a>?")
-    (jg_urlize @@ Tstr "want to go to http://user@foo:8080/bar/?baz=0?") 
+    (jg_urlize @@ Tstr "want to go to http://user@foo:8080/bar/?baz=0?") ;
+  assert_equal_tvalue
+    (Tstr "(<a href=\"http://foo.foo\">http://foo.foo</a>)")
+    (jg_urlize @@ Tstr "(http://foo.foo)") ;
+  assert_equal_tvalue
+    (Tstr "<a href=\"http://gallica.bnf.fr/ark:/12148/bpt6k1249555/f41.image\">\
+           http://gallica.bnf.fr/ark:/12148/bpt6k1249555/f41.image</a><br>Le 20 juin 1794")
+    (jg_urlize @@ Tstr "http://gallica.bnf.fr/ark:/12148/bpt6k1249555/f41.image<br>Le 20 juin 1794") ;
+  assert_equal_tvalue
+    (Tstr "(<a href=\"http://foo.foo/foo(foo)(foo)\">http://foo.foo/foo(foo)(foo)</a>)")
+    (jg_urlize @@ Tstr "(http://foo.foo/foo(foo)(foo))")
 
 let test_title _ctx =
   assert_equal_tvalue


### PR DESCRIPTION
In real world, it is likely to find this kind of input: `Bla bla bla (see http://some.url) bla bla`.

While `http://some.url)` seems to be a valid url, this is probably not want you want, so I chose to include `)` `]` and `}` only if an opening character has been parsed.

Also, as urls between quotes are likely to be html attributes, we do not turn them into a link.