### PR TITLE
Parser enhancement, tvalue unwrapping.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.4)
+(using menhir 2.0)

--- a/example/samples/is.jingoo
+++ b/example/samples/is.jingoo
@@ -1,7 +1,7 @@
 - 6 is divisibleby 4: {{ 6 is divisibleby 4 }}
-- 6 is divisibleby (4): {% 6 is divisibleby (4) %}
+- 6 is divisibleby (4): {{ 6 is divisibleby (4) }}
 - divisibleby(3,6): {{ divisibleby(3,6) }}
-- 3 is iterable: {% 3 is iterable %}
-- [1,2,3] is iterable: {% [1,2,3] is iterable %}
+- 3 is iterable: {{ 3 is iterable }}
+- [1,2,3] is iterable: {{ [1,2,3] is iterable }}
 - "hoge" is iterable: {{ "hoge" is iterable }}
-- null is iterable: {% null is iterable %}
+- null is iterable: {{ null is iterable }}

--- a/example/test.ml
+++ b/example/test.ml
@@ -48,6 +48,8 @@ let ls dir filter =
     in
     loop [] [dir]
 
+let status = ref 0
+
 let test jingoo_f =
   let html_f = filename_remove_extension jingoo_f ^ ".expected" in
   let models_f = filename_remove_extension jingoo_f ^ ".models" in
@@ -72,10 +74,12 @@ let test jingoo_f =
       prerr_endline @@ expected ;
       prerr_endline @@ "--- Got: " ;
       prerr_endline @@ res ;
-  with Failure s ->
+  with e ->
     prerr_endline @@ "--- Failure: " ^ jingoo_f ;
-    prerr_endline @@ s
+    prerr_endline @@ Printexc.to_string e ;
+    status := 1
 
 let () =
   let jingoo = ls (Sys.getenv "DOC_SAMPLE_DIR") (fun f -> filename_extension f = ".jingoo") in
-  List.iter test (List.sort compare jingoo)
+  List.iter test (List.sort compare jingoo) ;
+  exit !status

--- a/jingoo.opam
+++ b/jingoo.opam
@@ -12,6 +12,7 @@ remove: [make "uninstall"]
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {build & >= "1.4.0"}
+  "menhir"
   "ppx_deriving"
   "re"
   "uutf" {>= "0.9.4"}

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
-(menhir (modules jg_parser) )
+(menhir (flags (--explain)) (modules jg_parser) )
 
 (ocamllex (modules jg_lexer) )
 

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
-(ocamlyacc (modules jg_parser) )
+(menhir (modules jg_parser) )
 
 (ocamllex (modules jg_lexer) )
 

--- a/src/jg_ast_mapper.ml
+++ b/src/jg_ast_mapper.ml
@@ -53,6 +53,11 @@ and statement self stmt : statement = match stmt with
     IfStatement (List.map (fun (e, ast) -> ( (match e with Some e -> Some (self.expression self e) | None -> None)
                                            , self.ast self ast) ) branches)
 
+  | SwitchStatement (e, cases) ->
+    SwitchStatement ( self.expression self e
+                    , List.map (fun (e, ast) -> ( List.map (self.expression self) e
+                                                , self.ast self ast) ) cases)
+
   | ForStatement (ids, e2, ast) ->
     ForStatement (ids, self.expression self e2, self.ast self ast)
 

--- a/src/jg_ast_mapper.ml
+++ b/src/jg_ast_mapper.ml
@@ -79,24 +79,24 @@ and statement self stmt : statement = match stmt with
   | SetStatement (e1, e2) ->
     SetStatement (self.expression self e1, self.expression self e2)
 
-  | BlockStatement (e, ast) ->
-    BlockStatement (self.expression self e, self.ast self ast)
+  | BlockStatement (n, ast) ->
+    BlockStatement (n, self.ast self ast)
 
-  | MacroStatement (e, args, ast) ->
-    MacroStatement ( self.expression self e
+  | MacroStatement (n, args, ast) ->
+    MacroStatement ( n
                    , arguments_definition self args
                    , self.ast self ast)
 
-  | FunctionStatement (e, args, ast) ->
-    FunctionStatement ( self.expression self e
+  | FunctionStatement (n, args, ast) ->
+    FunctionStatement ( n
                       , arguments_definition self args
                       , self.ast self ast)
 
-  | FilterStatement (e, ast) ->
-    FilterStatement (self.expression self e, self.ast self ast)
+  | FilterStatement (n, ast) ->
+    FilterStatement (n, self.ast self ast)
 
-  | CallStatement (e, a1, a2, ast) ->
-    CallStatement ( self.expression self e
+  | CallStatement (n, a1, a2, ast) ->
+    CallStatement ( n
                   , arguments_definition self a1
                   , arguments_application self a2
                   , self.ast self ast)

--- a/src/jg_ast_mapper.ml
+++ b/src/jg_ast_mapper.ml
@@ -184,7 +184,7 @@ and expression self expr = match expr with
     SetExpr (List.map (self.expression self) el)
 
   | ObjExpr (eel) ->
-    ObjExpr (List.map (fun (e1, e2) -> self.expression self e1, self.expression self e2) eel)
+    ObjExpr (List.map (fun (k, v) -> k, self.expression self v) eel)
 
   | TestOpExpr (e1, e2) ->
     TestOpExpr (self.expression self e1, self.expression self e2)

--- a/src/jg_ast_mapper.ml
+++ b/src/jg_ast_mapper.ml
@@ -89,7 +89,7 @@ and statement self stmt : statement = match stmt with
                   , self.ast self ast)
 
   | WithStatement (el, ast) ->
-    WithStatement ( List.map (self.expression self) el
+    WithStatement ( List.map (fun (n, e) -> (n, self.expression self e)) el
                   , self.ast self ast)
 
   | AutoEscapeStatement (e, ast) ->

--- a/src/jg_ast_mapper.ml
+++ b/src/jg_ast_mapper.ml
@@ -53,8 +53,8 @@ and statement self stmt : statement = match stmt with
     IfStatement (List.map (fun (e, ast) -> ( (match e with Some e -> Some (self.expression self e) | None -> None)
                                            , self.ast self ast) ) branches)
 
-  | ForStatement (e1, e2, ast) ->
-    ForStatement ( self.expression self e1, self.expression self e2, self.ast self ast)
+  | ForStatement (ids, e2, ast) ->
+    ForStatement (ids, self.expression self e2, self.ast self ast)
 
   | IncludeStatement (e, b) ->
     IncludeStatement (self.expression self e, b)

--- a/src/jg_ast_optimize.ml
+++ b/src/jg_ast_optimize.ml
@@ -89,3 +89,18 @@ let dead_code_elimination stmts =
     | s -> default_mapper.statement self s in
   let mapper = { default_mapper with statement } in
   mapper.ast mapper stmts
+
+(** [inline_include env ast]
+    Inline the templates included in [ast] so it won't be necessary to
+    open and parse theses parts when execution [ast].
+*)
+let inline_include env stmts =
+  let open Jg_ast_mapper in
+  let statement self = function
+    | IncludeStatement (LiteralExpr (Tstr file), true) ->
+      Statements (self.ast self @@ Jg_interp.ast_from_file ~env file)
+    | RawIncludeStatement (LiteralExpr (Tstr file)) ->
+      Statements (self.ast self @@ Jg_interp.ast_from_file ~env file)
+    | e -> default_mapper.statement self e in
+  let mapper = { default_mapper with statement } in
+  mapper.ast mapper stmts

--- a/src/jg_ast_optimize.ml
+++ b/src/jg_ast_optimize.ml
@@ -23,7 +23,7 @@ let dead_code_elimination stmts =
   let rec maybe_set = function
     | SetExpr set -> List.iter maybe_set set
     | IdentExpr id -> set_local id
-    | KeywordExpr (id, _) -> maybe_set id
+    (* | KeywordExpr (id, _) -> maybe_set id *)
     | _ -> () in
   let statement self = function
     | SetStatement (id, _) as s ->
@@ -39,7 +39,7 @@ let dead_code_elimination stmts =
     | MacroStatement (IdentExpr id, args, _) as s ->
       push_block id ;
       set_local id ;
-      List.iter maybe_set args ;
+      List.iter (fun (i, _) -> set_local i) args ;
       let s = default_mapper.statement self s in
       pop_block () ;
       s

--- a/src/jg_ast_optimize.ml
+++ b/src/jg_ast_optimize.ml
@@ -23,15 +23,14 @@ let dead_code_elimination stmts =
   let rec maybe_set = function
     | SetExpr set -> List.iter maybe_set set
     | IdentExpr id -> set_local id
-    (* | KeywordExpr (id, _) -> maybe_set id *)
     | _ -> () in
   let statement self = function
     | SetStatement (id, _) as s ->
       maybe_set id ;
       default_mapper.statement self s
-    | ForStatement (id, _, _) as s ->
+    | ForStatement (ids, _, _) as s ->
       push_block "" ;
-      List.iter set_local id ;
+      List.iter set_local ids ;
       let s = default_mapper.statement self s in
       pop_block () ;
       s

--- a/src/jg_ast_optimize.ml
+++ b/src/jg_ast_optimize.ml
@@ -31,7 +31,7 @@ let dead_code_elimination stmts =
       default_mapper.statement self s
     | ForStatement (id, _, _) as s ->
       push_block "" ;
-      maybe_set id ;
+      List.iter set_local id ;
       let s = default_mapper.statement self s in
       pop_block () ;
       s

--- a/src/jg_ast_optimize.ml
+++ b/src/jg_ast_optimize.ml
@@ -34,19 +34,17 @@ let dead_code_elimination stmts =
       let s = default_mapper.statement self s in
       pop_block () ;
       s
-    | FunctionStatement (IdentExpr id, args, _)
-    | MacroStatement (IdentExpr id, args, _) as s ->
+    | FunctionStatement (id, args, _)
+    | MacroStatement (id, args, _) as s ->
       push_block id ;
       set_local id ;
       List.iter (fun (i, _) -> set_local i) args ;
       let s = default_mapper.statement self s in
       pop_block () ;
       s
-    | CallStatement(macro, _, _, _) as s ->
-      maybe_set macro ;
+    | CallStatement(id, _, _, _) as s ->
+      set_local id ;
       default_mapper.statement self s
-    | FunctionStatement (_, _, _)
-    | MacroStatement (_, _, _)
     | TextStatement (_)
     | ExpandStatement (_)
     | IfStatement (_)
@@ -71,8 +69,8 @@ let dead_code_elimination stmts =
   let mapper = { default_mapper with expression ; statement } in
   let _ = mapper.ast mapper stmts in
   let statement self = function
-    | MacroStatement (IdentExpr id, _, _)
-    | FunctionStatement (IdentExpr id, _, _) as s ->
+    | MacroStatement (id, _, _)
+    | FunctionStatement (id, _, _) as s ->
       (* Find if name is present in instructions called from toplevel *)
       let rec loop n lists =
         if List.mem "" (List.hd lists) then default_mapper.statement self s

--- a/src/jg_ast_optimize.ml
+++ b/src/jg_ast_optimize.ml
@@ -51,6 +51,7 @@ let dead_code_elimination stmts =
     | TextStatement (_)
     | ExpandStatement (_)
     | IfStatement (_)
+    | SwitchStatement (_, _)
     | IncludeStatement (_, _)
     | RawIncludeStatement _
     | ExtendsStatement _

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -65,12 +65,8 @@ let rec value_of_expr env ctx = function
   | TestOpExpr(IdentExpr(name), IdentExpr("lower")) -> jg_test_lower (jg_get_value ctx name)
   | TestOpExpr(target, test) -> jg_apply (value_of_expr env ctx test) [value_of_expr env ctx target]
 
-  | ObjExpr(expr_list) ->
-    Tobj (List.map (function
-      | IdentExpr(name), expr -> (name, value_of_expr env ctx expr)
-      | LiteralExpr(Tstr(name)), expr -> (name, value_of_expr env ctx expr)
-      | _, _ -> failwith "invalid object syntax"
-    ) expr_list)
+  | ObjExpr(key_values) ->
+    Tobj (List.map (fun (k, v) -> (k, value_of_expr env ctx v)) key_values)
 
   | ApplyExpr(IdentExpr("eval"), [name, expr]) ->
     assert (name = None) ;

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -305,17 +305,6 @@ and replace_blocks stmts =
     let mapper = { default_mapper with statement } in
     mapper.ast mapper stmts
 
-and inline_include env stmts =
-  let open Jg_ast_mapper in
-  let statement self = function
-    | IncludeStatement (LiteralExpr (Tstr file), true) ->
-      Statements (self.ast self @@ ast_from_file ~env file)
-    | RawIncludeStatement (LiteralExpr (Tstr file)) ->
-      Statements (self.ast self @@ ast_from_file ~env file)
-    | e -> default_mapper.statement self e in
-  let mapper = { default_mapper with statement } in
-  mapper.ast mapper stmts
-
 (* Import macros into ctx and remove it from ast *)
 and import_macros env ctx stmts =
   let open Jg_ast_mapper in

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -226,8 +226,8 @@ and eval_statement env ctx = function
     end
 
   | WithStatement(binds, ast) ->
-    let kwargs = kwargs_of env ctx binds in
-    let names, values = List.split kwargs in
+    let names, values = List.split binds in
+    let values = List.map (value_of_expr env ctx) values in
     let ctx' = jg_push_frame ctx in
     let () = jg_set_values ctx' names values in
     ignore @@ List.fold_left (eval_statement env) ctx' ast ;

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -174,6 +174,18 @@ and eval_statement env ctx = function
     in
     List.fold_left (eval_statement env) ctx @@ select_case branches
 
+  | SwitchStatement (e, cases) ->
+    let e = value_of_expr env ctx e in
+    let rec select_case = function
+      | ([], ast) :: _ -> ast
+      | (cond, ast) :: tl ->
+        if List.exists (fun x -> jg_eq_eq_aux (value_of_expr env ctx x) e) cond
+        then ast
+        else select_case tl
+      | [] -> []
+    in
+    List.fold_left (eval_statement env) ctx @@ select_case cases
+
   | ForStatement(iterator, iterable_expr, ast) ->
     let iterable = value_of_expr env ctx iterable_expr in
     let is_iterable = Jg_runtime.jg_test_iterable_aux iterable in

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -179,11 +179,6 @@ and eval_statement env ctx = function
     List.fold_left (eval_statement env) ctx @@ select_case branches
 
   | ForStatement(iterator, iterable_expr, ast) ->
-    let iterator =
-      match iterator with
-      | IdentExpr(name) -> [name]
-      | SetExpr(lst) -> ident_names_of lst
-      | _ -> failwith "invalid iterator" in
     let iterable = value_of_expr env ctx iterable_expr in
     let is_iterable = Jg_runtime.jg_test_iterable_aux iterable in
     (* [ISSUE#23] when strict_mode is enabled, raises error if loop target is not iterable. *)

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -86,6 +86,9 @@
       | `Html ->
 	add_char chr;
 	lexer lexb
+
+  let queue = ref []
+
 }
 
 let blank = [ ' ' '\t' ]
@@ -96,6 +99,17 @@ let float_literal = ['0'-'9']+('.' ['0'-'9']*)? (['e' 'E'] ['+' '-']? ['0'-'9']+
 let newline = [ '\n' ]
 
 rule main = parse
+| "" { match !queue with [] -> main_bis lexbuf | hd :: tl -> queue := tl ; hd }
+| eof {
+    match get_buf () with
+    | "" -> begin match !queue with
+        | [] -> EOF
+        | hd :: tl -> queue := tl ; hd
+      end
+    | s -> TEXT s
+  }
+
+and main_bis = parse
   | '\\' '{' {
     add_char '{';
     main lexbuf
@@ -122,6 +136,7 @@ rule main = parse
     if ctx.mode = `Logic then fail lexbuf @@ "Unexpected '{{' token" ;
     update_context `Logic (Some "}}");
     (* print_endline @@ spf "text:%s" (Buffer.contents buf); *)
+    queue := !queue @ [ OPEN_EXPRESSION ] ;
     match get_buf () with
       | "" -> main lexbuf
       | content -> TEXT content
@@ -140,7 +155,7 @@ rule main = parse
 	add_str str; main lexbuf
       | Some "}}" ->
 	update_context `Html None;
-	main lexbuf
+        CLOSE_EXPRESSION
       | _ -> fail lexbuf @@ spf "syntax error '%s'" str
   }
   | ("%}" | "-%}" (blank | newline)*) as str {
@@ -256,9 +271,6 @@ rule main = parse
     match ctx.mode with
       | `Html -> add_char c; main lexbuf
       | _ -> fail lexbuf @@ spf "unexpected token:%c" c
-  }
-  | eof {
-      match get_buf () with "" -> EOF | s -> TEXT s
   }
 
 and comment = parse

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -192,6 +192,10 @@ and main_bis = parse
   | "else" as s { token_or_str (s, ELSE) main lexbuf }
   | ("elseif" | "elif") as s { token_or_str (s, ELSEIF) main lexbuf }
   | "endif" as s { token_or_str (s, ENDIF) main lexbuf }
+  | "switch" as s { token_or_str (s, SWITCH) main lexbuf }
+  | "case" as s { token_or_str (s, CASE) main lexbuf }
+  | "default" as s { token_or_str (s, DEFAULT) main lexbuf }
+  | "endswitch" as s { token_or_str (s, ENDSWITCH) main lexbuf }
   | "for" as s { token_or_str (s, FOR) main lexbuf }
   | "endfor" as s { token_or_str (s, ENDFOR) main lexbuf }
   | "include" as s { token_or_str (s, INCLUDE) main lexbuf }

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -159,7 +159,6 @@ expr:
   ident { pel "ident"; $1 }
 | ident EQ expr { pel "keyword"; KeywordExpr($1, $3) }
 | ident AS ident { pel "alias"; AliasExpr($1, $3) }
-| ident LPAREN separated_list(COMMA, expr) RPAREN { pel "apply(expr_list)"; ApplyExpr($1, $3) }
 | expr LPAREN separated_list(COMMA, expr) RPAREN { pel "apply(expr_list)"; ApplyExpr($1, $3) }
 | INT { pel "int"; LiteralExpr (Tint $1) }
 | FLOAT { pel "float"; LiteralExpr (Tfloat $1) }

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -138,13 +138,13 @@ stmt:
 | RAWINCLUDE error { raise @@ SyntaxError "rawinclude" }
 | IMPORT STRING as_part { pel "import sts"; ImportStatement($2, $3) }
 | IMPORT error{ raise @@ SyntaxError "import error" }
-| FROM STRING IMPORT expr_list { pel "from import sts"; FromImportStatement($2, $4) }
+| FROM STRING IMPORT separated_list(COMMA, expr) { pel "from import sts"; FromImportStatement($2, $4) }
 | FROM error{ raise @@ SyntaxError "from import error" }
-| MACRO ident LPAREN expr_list RPAREN stmts ENDMACRO { pel "macro sts"; MacroStatement($2, $4, $6) }
+| MACRO ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDMACRO { pel "macro sts"; MacroStatement($2, $4, $6) }
 | MACRO error { raise @@ SyntaxError "macro" }
-| FUNCTION ident LPAREN expr_list RPAREN stmts ENDFUNCTION { pel "function sts"; FunctionStatement($2, $4, $6) }
+| FUNCTION ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDFUNCTION { pel "function sts"; FunctionStatement($2, $4, $6) }
 | FUNCTION error { raise @@ SyntaxError "function" }
-| CALL opt_args ident LPAREN expr_list RPAREN stmts ENDCALL { pel "call sts"; CallStatement($3, $2, $5, $7) }
+| CALL opt_args ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDCALL { pel "call sts"; CallStatement($3, $2, $5, $7) }
 | CALL error { raise @@ SyntaxError "call error" }
 | IF
   i = pair(expr, stmt*)
@@ -160,7 +160,7 @@ stmt:
 | FOR ident_list IN expr stmts ENDFOR { pel "for sts"; ForStatement(SetExpr($2), $4, $5) }
 | FOR expr IN expr stmts ENDFOR { pel "for sts"; ForStatement($2, $4, $5) }
 | FOR error { raise @@ SyntaxError "for" }
-| WITH expr_list stmts ENDWITH { pel "with sts1"; WithStatement($2, $3) }
+| WITH separated_list(COMMA, expr) stmts ENDWITH { pel "with sts1"; WithStatement($2, $3) }
 | WITH error { raise @@ SyntaxError "with" }
 | AUTOESCAPE expr stmts ENDAUTOESCAPE { pel "autoescape"; AutoEscapeStatement($2, $3) }
 | AUTOESCAPE error { raise @@ SyntaxError "autoescape" }
@@ -191,19 +191,12 @@ ident_list:
 | ident COMMA error { raise @@ SyntaxError "ident_list" }
 ;
 
-expr_list:
-/* empty */ { pel "empty expr list"; [] }
-| expr { pel "expr list"; [$1] }
-| expr COMMA expr_list { pel "expr list comma"; $1 :: $3 }
-| expr COMMA error { raise @@ SyntaxError "expr_list" }
-;
-
 expr:
   ident { pel "ident"; $1 }
 | ident EQ expr { pel "keyword"; KeywordExpr($1, $3) }
 | ident AS ident { pel "alias"; AliasExpr($1, $3) }
-| ident LPAREN expr_list RPAREN { pel "apply(expr_list)"; ApplyExpr($1, $3) }
-| expr LPAREN expr_list RPAREN { pel "apply(expr_list)"; ApplyExpr($1, $3) }
+| ident LPAREN separated_list(COMMA, expr) RPAREN { pel "apply(expr_list)"; ApplyExpr($1, $3) }
+| expr LPAREN separated_list(COMMA, expr) RPAREN { pel "apply(expr_list)"; ApplyExpr($1, $3) }
 | INT { pel "int"; LiteralExpr (Tint $1) }
 | FLOAT { pel "float"; LiteralExpr (Tfloat $1) }
 | TRUE { pel "true"; LiteralExpr (Tbool true) }
@@ -214,7 +207,7 @@ expr:
 | expr LBRACKET expr RBRACKET { pel "bracket_lookup"; BracketExpr($1, $3) }
 | NOT expr { pel "not expr"; NotOpExpr($2) }
 | MINUS expr %prec UMINUS { pel "negative"; NegativeOpExpr($2) }
-| LBRACKET expr_list RBRACKET { pel "list expr"; ListExpr($2) }
+| LBRACKET separated_list(COMMA, expr) RBRACKET { pel "list expr"; ListExpr($2) }
 | LBRACE separated_list(COMMA, separated_pair(expr, COLON, expr)) RBRACE { pel "obj expr"; ObjExpr($2) }
 | expr PLUS expr { pel "plus"; PlusOpExpr($1, $3) }
 | expr MINUS expr { pel "minus"; MinusOpExpr($1, $3) }
@@ -240,11 +233,11 @@ expr:
 }
 | expr IS expr { pel "test"; TestOpExpr($1,$3) }
 | LPAREN expr RPAREN { pel "(expr)"; $2 }
-| LPAREN expr_list RPAREN { pel "set expr"; SetExpr($2) }
+| LPAREN separated_list(COMMA, expr) RPAREN { pel "set expr"; SetExpr($2) }
 | LPAREN error { raise @@ SyntaxError "expr" }
 ;
 
 opt_args:
 /* empty */ { pel "opt_args empty"; [] }
-| LPAREN expr_list RPAREN { $2 }
+| LPAREN separated_list(COMMA, expr) RPAREN { $2 }
 ;

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -142,7 +142,8 @@ stmt:
 | FOR ident preceded(COMMA, ident)+ IN expr stmt* ENDFOR
   { pel "for sts"; ForStatement(SetExpr($2 :: $3), $5, $6) }
 | FOR expr IN expr stmt* ENDFOR { pel "for sts"; ForStatement($2, $4, $5) }
-| WITH separated_list(COMMA, expr) stmt* ENDWITH { pel "with sts1"; WithStatement($2, $3) }
+| WITH separated_list(COMMA, separated_pair(IDENT, EQ, expr)) stmt* ENDWITH
+  { pel "with sts1"; WithStatement($2, $3) }
 | AUTOESCAPE expr stmt* ENDAUTOESCAPE { pel "autoescape"; AutoEscapeStatement($2, $3) }
 | TEXT { pel "text sts"; TextStatement($1) }
 ;

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -127,17 +127,17 @@ stmt:
       | idents, exprs -> pel "set sts"; SetStatement (SetExpr idents, exprs)
     }
 | EXTENDS STRING { pel "extends sts"; ExtendsStatement($2) }
-| BLOCK ident stmt* ENDBLOCK { pel "block sts2"; BlockStatement($2, $3) }
-| FILTER ident stmt* ENDFILTER { pel "filter sts"; FilterStatement($2, $3) }
+| BLOCK IDENT stmt* ENDBLOCK { pel "block sts2"; BlockStatement($2, $3) }
+| FILTER IDENT stmt* ENDFILTER { pel "filter sts"; FilterStatement($2, $3) }
 | INCLUDE expr context? { pel "include sts"; IncludeStatement($2, $3 <> Some false) }
 | RAWINCLUDE expr { pel "raw include sts"; RawIncludeStatement($2) }
 | IMPORT STRING preceded(AS, IDENT)? { pel "import sts"; ImportStatement($2, $3) }
 | FROM STRING IMPORT separated_list(COMMA, alias) { pel "from import sts"; FromImportStatement($2, $4) }
-| MACRO ident LPAREN separated_list(COMMA, argument_definition) RPAREN stmt* ENDMACRO
+| MACRO IDENT LPAREN separated_list(COMMA, argument_definition) RPAREN stmt* ENDMACRO
   { pel "macro sts"; MacroStatement($2, $4, $6) }
-| FUNCTION ident LPAREN separated_list(COMMA, argument_definition) RPAREN stmt* ENDFUNCTION
+| FUNCTION IDENT LPAREN separated_list(COMMA, argument_definition) RPAREN stmt* ENDFUNCTION
   { pel "function sts"; FunctionStatement($2, $4, $6) }
-| CALL opt_args ident LPAREN separated_list(COMMA, argument_application) RPAREN stmt* ENDCALL
+| CALL opt_args IDENT LPAREN separated_list(COMMA, argument_application) RPAREN stmt* ENDCALL
   { pel "call sts"; CallStatement($3, $2, $5, $7) }
 | IF
   i = pair(expr, stmt*)

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -118,7 +118,7 @@ stmt:
 | EXTENDS STRING { pel "extends sts"; ExtendsStatement($2) }
 | BLOCK ident stmt* ENDBLOCK { pel "block sts2"; BlockStatement($2, $3) }
 | FILTER ident stmt* ENDFILTER { pel "filter sts"; FilterStatement($2, $3) }
-| INCLUDE expr context_part{ pel "include sts"; IncludeStatement($2, $3) }
+| INCLUDE expr context? { pel "include sts"; IncludeStatement($2, $3 <> Some false) }
 | RAWINCLUDE expr { pel "raw include sts"; RawIncludeStatement($2) }
 | IMPORT STRING preceded(AS, IDENT)? { pel "import sts"; ImportStatement($2, $3) }
 | FROM STRING IMPORT separated_list(COMMA, expr) { pel "from import sts"; FromImportStatement($2, $4) }
@@ -148,8 +148,7 @@ stmt:
 | TEXT { pel "text sts"; TextStatement($1) }
 ;
 
-context_part:
-/* empty */ { true }
+%inline context:
 | WITH CONTEXT { true }
 | WITHOUT CONTEXT { false }
 ;

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -161,6 +161,8 @@ stmt:
 
 %inline ident: IDENT { IdentExpr $1 }
 
+%inline objkey: IDENT {  $1 } | STRING { $1 }
+
 expr:
   ident { pel "ident"; $1 }
 | INT { pel "int"; LiteralExpr (Tint $1) }
@@ -174,7 +176,8 @@ expr:
 | NOT expr { pel "not expr"; NotOpExpr($2) }
 | MINUS expr %prec UMINUS { pel "negative"; NegativeOpExpr($2) }
 | LBRACKET separated_list(COMMA, expr) RBRACKET { pel "list expr"; ListExpr($2) }
-| LBRACE separated_list(COMMA, separated_pair(expr, COLON, expr)) RBRACE { pel "obj expr"; ObjExpr($2) }
+| LBRACE o=separated_list(COMMA, separated_pair(objkey, COLON, expr)) RBRACE
+  { pel "obj expr"; ObjExpr o }
 | expr PLUS expr { pel "plus"; PlusOpExpr($1, $3) }
 | expr MINUS expr { pel "minus"; MinusOpExpr($1, $3) }
 | expr DIV expr { pel "div"; DivOpExpr($1, $3) }

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -112,7 +112,6 @@ stmts:
 
 stmt:
   expr { pel "expand expr"; ExpandStatement($1) }
-| error { raise @@ SyntaxError "expand stmt error" }
 | SET ident DOT ident EQ expr { pel "set"; SetStatement (DotExpr ($2, ident_name $4), $6) }
 | SET ident_list EQ expr {
       pel "set";
@@ -124,28 +123,17 @@ stmt:
          NamespaceStatement (ident_name n, List.map extract_assign init)
       | _ -> pel "set sts"; SetStatement(SetExpr($2), $4)
     }
-| SET error { raise @@ SyntaxError "set" }
 | EXTENDS STRING { pel "extends sts"; ExtendsStatement($2) }
-| EXTENDS error { raise @@ SyntaxError "extends" }
 | BLOCK ident ENDBLOCK { pel "block sts"; BlockStatement($2, []) }
 | BLOCK ident stmts ENDBLOCK { pel "block sts2"; BlockStatement($2, $3) }
-| BLOCK error { raise @@ SyntaxError "block" }
 | FILTER ident stmts ENDFILTER { pel "filter sts"; FilterStatement($2, $3) }
-| FILTER error { raise @@ SyntaxError "filter" }
 | INCLUDE expr context_part{ pel "include sts"; IncludeStatement($2, $3) }
-| INCLUDE error { raise @@ SyntaxError "include" }
 | RAWINCLUDE expr { pel "raw include sts"; RawIncludeStatement($2) }
-| RAWINCLUDE error { raise @@ SyntaxError "rawinclude" }
 | IMPORT STRING as_part { pel "import sts"; ImportStatement($2, $3) }
-| IMPORT error{ raise @@ SyntaxError "import error" }
 | FROM STRING IMPORT separated_list(COMMA, expr) { pel "from import sts"; FromImportStatement($2, $4) }
-| FROM error{ raise @@ SyntaxError "from import error" }
 | MACRO ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDMACRO { pel "macro sts"; MacroStatement($2, $4, $6) }
-| MACRO error { raise @@ SyntaxError "macro" }
 | FUNCTION ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDFUNCTION { pel "function sts"; FunctionStatement($2, $4, $6) }
-| FUNCTION error { raise @@ SyntaxError "function" }
 | CALL opt_args ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDCALL { pel "call sts"; CallStatement($3, $2, $5, $7) }
-| CALL error { raise @@ SyntaxError "call error" }
 | IF
   i = pair(expr, stmt*)
   ei = preceded(ELSEIF, pair(expr, stmt*))*
@@ -159,13 +147,9 @@ stmt:
   }
 | FOR ident_list IN expr stmts ENDFOR { pel "for sts"; ForStatement(SetExpr($2), $4, $5) }
 | FOR expr IN expr stmts ENDFOR { pel "for sts"; ForStatement($2, $4, $5) }
-| FOR error { raise @@ SyntaxError "for" }
 | WITH separated_list(COMMA, expr) stmts ENDWITH { pel "with sts1"; WithStatement($2, $3) }
-| WITH error { raise @@ SyntaxError "with" }
 | AUTOESCAPE expr stmts ENDAUTOESCAPE { pel "autoescape"; AutoEscapeStatement($2, $3) }
-| AUTOESCAPE error { raise @@ SyntaxError "autoescape" }
 | TEXT { pel "text sts"; TextStatement($1) }
-| TEXT error { raise @@ SyntaxError "text" }
 ;
 
 as_part:

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -99,13 +99,7 @@
 %%
 
 input:
-  EOF { [] }
-| stmts EOF { $1 }
-;
-
-stmts:
-  stmt { [$1] }
-| stmt stmts { $1 :: $2 }
+  stmt* EOF { $1 }
 ;
 
 stmt:
@@ -123,16 +117,16 @@ stmt:
     }
 | EXTENDS STRING { pel "extends sts"; ExtendsStatement($2) }
 | BLOCK ident stmt* ENDBLOCK { pel "block sts2"; BlockStatement($2, $3) }
-| FILTER ident stmts ENDFILTER { pel "filter sts"; FilterStatement($2, $3) }
+| FILTER ident stmt* ENDFILTER { pel "filter sts"; FilterStatement($2, $3) }
 | INCLUDE expr context_part{ pel "include sts"; IncludeStatement($2, $3) }
 | RAWINCLUDE expr { pel "raw include sts"; RawIncludeStatement($2) }
 | IMPORT STRING preceded(AS, IDENT)? { pel "import sts"; ImportStatement($2, $3) }
 | FROM STRING IMPORT separated_list(COMMA, expr) { pel "from import sts"; FromImportStatement($2, $4) }
-| MACRO ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDMACRO
+| MACRO ident LPAREN separated_list(COMMA, expr) RPAREN stmt* ENDMACRO
   { pel "macro sts"; MacroStatement($2, $4, $6) }
-| FUNCTION ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDFUNCTION
+| FUNCTION ident LPAREN separated_list(COMMA, expr) RPAREN stmt* ENDFUNCTION
   { pel "function sts"; FunctionStatement($2, $4, $6) }
-| CALL opt_args ident LPAREN separated_list(COMMA, expr) RPAREN stmts ENDCALL
+| CALL opt_args ident LPAREN separated_list(COMMA, expr) RPAREN stmt* ENDCALL
   { pel "call sts"; CallStatement($3, $2, $5, $7) }
 | IF
   i = pair(expr, stmt*)
@@ -145,11 +139,11 @@ stmt:
                  (fun (a, b) acc -> (Some a, b) :: acc) (i :: ei)
                  (match e with None -> [] | Some stmts -> [ (None, stmts) ]))
   }
-| FOR ident preceded(COMMA, ident)+ IN expr stmts ENDFOR
+| FOR ident preceded(COMMA, ident)+ IN expr stmt* ENDFOR
   { pel "for sts"; ForStatement(SetExpr($2 :: $3), $5, $6) }
-| FOR expr IN expr stmts ENDFOR { pel "for sts"; ForStatement($2, $4, $5) }
-| WITH separated_list(COMMA, expr) stmts ENDWITH { pel "with sts1"; WithStatement($2, $3) }
-| AUTOESCAPE expr stmts ENDAUTOESCAPE { pel "autoescape"; AutoEscapeStatement($2, $3) }
+| FOR expr IN expr stmt* ENDFOR { pel "for sts"; ForStatement($2, $4, $5) }
+| WITH separated_list(COMMA, expr) stmt* ENDWITH { pel "with sts1"; WithStatement($2, $3) }
+| AUTOESCAPE expr stmt* ENDAUTOESCAPE { pel "autoescape"; AutoEscapeStatement($2, $3) }
 | TEXT { pel "text sts"; TextStatement($1) }
 ;
 

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -215,7 +215,7 @@ expr:
 | NOT expr { pel "not expr"; NotOpExpr($2) }
 | MINUS expr %prec UMINUS { pel "negative"; NegativeOpExpr($2) }
 | LBRACKET expr_list RBRACKET { pel "list expr"; ListExpr($2) }
-| LBRACE assoc_list RBRACE { pel "obj expr"; ObjExpr($2) }
+| LBRACE separated_list(COMMA, separated_pair(expr, COLON, expr)) RBRACE { pel "obj expr"; ObjExpr($2) }
 | expr PLUS expr { pel "plus"; PlusOpExpr($1, $3) }
 | expr MINUS expr { pel "minus"; MinusOpExpr($1, $3) }
 | expr DIV expr { pel "div"; DivOpExpr($1, $3) }
@@ -242,17 +242,6 @@ expr:
 | LPAREN expr RPAREN { pel "(expr)"; $2 }
 | LPAREN expr_list RPAREN { pel "set expr"; SetExpr($2) }
 | LPAREN error { raise @@ SyntaxError "expr" }
-;
-
-assoc_list:
-  assoc { pel "assoc list1"; [$1] }
-| assoc COMMA assoc_list { pel "assoc list2"; $1 :: $3 }
-| assoc COMMA error { raise @@ SyntaxError "assoc list error" }
-;
-
-assoc:
-  expr COLON expr { ($1, $3) }
-| expr error { raise @@ SyntaxError "assoc error" }
 ;
 
 opt_args:

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -94,6 +94,8 @@
 %nonassoc NOT UMINUS
 %left DOT
 
+%right LPAREN LBRACKET
+
 %start input
 %type <Jg_types.ast> input
 

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -144,9 +144,8 @@ stmt:
                  (fun (a, b) acc -> (Some a, b) :: acc) (i :: ei)
                  (match e with None -> [] | Some stmts -> [ (None, stmts) ]))
   }
-| FOR LPAREN? separated_nonempty_list(COMMA, ident) RPAREN? IN expr stmt* ENDFOR
-  { pel "for sts"; ForStatement(SetExpr($3), $6, $7) }
-(* | FOR expr IN expr stmt* ENDFOR { pel "for sts"; ForStatement($2, $4, $5) } *)
+| FOR LPAREN? separated_nonempty_list(COMMA, IDENT) RPAREN? IN expr stmt* ENDFOR
+  { pel "for sts"; ForStatement($3, $6, $7) }
 | WITH separated_list(COMMA, separated_pair(IDENT, EQ, expr)) stmt* ENDWITH
   { pel "with sts1"; WithStatement($2, $3) }
 | AUTOESCAPE expr stmt* ENDAUTOESCAPE { pel "autoescape"; AutoEscapeStatement($2, $3) }

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -151,7 +151,7 @@ let jg_nth_aux value i =
   match value with
   | Tarray a -> a.(i)
   | Tset l | Tlist l -> List.nth l i
-  | Tstr s -> Tstr (String.make 1 @@ String.get s i)
+  | Tstr s -> Tstr (UTF8.sub s i 1)
   | _ -> failwith_type_error_1 "jg_nth_aux" value
 (**/**)
 

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -72,15 +72,15 @@ and statement =
   | ImportStatement of string * string option
   | FromImportStatement of string * (string * string option) list
   | SetStatement of expression * expression
-  | BlockStatement of expression * ast
-  | MacroStatement of expression * arguments * ast
-  | FilterStatement of expression * ast
-  | CallStatement of expression * arguments * (string option * expression) list * ast
+  | BlockStatement of string * ast
+  | MacroStatement of string * arguments * ast
+  | FilterStatement of string * ast
+  | CallStatement of string * arguments * (string option * expression) list * ast
   | WithStatement of (string * expression) list * ast
   | AutoEscapeStatement of expression * ast
   | NamespaceStatement of string * (string * expression) list
   | Statements of ast
-  | FunctionStatement of expression * arguments * ast
+  | FunctionStatement of string * arguments * ast
   | SwitchStatement of expression * (expression list * ast) list
 [@@deriving show { with_path = false }]
 

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -81,6 +81,7 @@ and statement =
   | NamespaceStatement of string * (string * expression) list
   | Statements of ast
   | FunctionStatement of expression * arguments * ast
+  | SwitchStatement of expression * (expression list * ast) list
 [@@deriving show { with_path = false }]
 
 and expression =

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -70,12 +70,12 @@ and statement =
   | RawIncludeStatement of expression
   | ExtendsStatement of string
   | ImportStatement of string * string option
-  | FromImportStatement of string * expression list
+  | FromImportStatement of string * (string * string option) list
   | SetStatement of expression * expression
   | BlockStatement of expression * ast
   | MacroStatement of expression * arguments * ast
   | FilterStatement of expression * ast
-  | CallStatement of expression * arguments * arguments * ast
+  | CallStatement of expression * arguments * (string option * expression) list * ast
   | WithStatement of (string * expression) list * ast
   | AutoEscapeStatement of expression * ast
   | NamespaceStatement of string * (string * expression) list
@@ -104,18 +104,16 @@ and expression =
   | GtEqOpExpr of expression * expression
   | DotExpr of expression * string
   | BracketExpr of expression * expression
-  | ApplyExpr of expression * arguments
+  | ApplyExpr of expression * (string option * expression) list
   | ListExpr of expression list
   | SetExpr of expression list
   | ObjExpr of (expression * expression) list
   | TestOpExpr of expression * expression
-  | KeywordExpr of expression * expression
-  | AliasExpr of expression * expression
   | InOpExpr of expression * expression
 
 and with_context = bool
 and branch = expression option * ast
-and arguments = expression list
+and arguments = (string * expression option) list
 
 (* If you modify this value, documentation in jg_types.mli *)
 let std_env = {

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -65,7 +65,7 @@ and statement =
     TextStatement of string
   | ExpandStatement of expression
   | IfStatement of branch list
-  | ForStatement of expression * expression * ast
+  | ForStatement of string list * expression * ast
   | IncludeStatement of expression * with_context
   | RawIncludeStatement of expression
   | ExtendsStatement of string

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -76,7 +76,7 @@ and statement =
   | MacroStatement of expression * arguments * ast
   | FilterStatement of expression * ast
   | CallStatement of expression * arguments * arguments * ast
-  | WithStatement of expression list * ast
+  | WithStatement of (string * expression) list * ast
   | AutoEscapeStatement of expression * ast
   | NamespaceStatement of string * (string * expression) list
   | Statements of ast

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -107,7 +107,7 @@ and expression =
   | ApplyExpr of expression * (string option * expression) list
   | ListExpr of expression list
   | SetExpr of expression list
-  | ObjExpr of (expression * expression) list
+  | ObjExpr of (string * expression) list
   | TestOpExpr of expression * expression
   | InOpExpr of expression * expression
 

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -86,12 +86,12 @@ and statement =
   | RawIncludeStatement of expression
   | ExtendsStatement of string
   | ImportStatement of string * string option
-  | FromImportStatement of string * expression list
+  | FromImportStatement of string * (string * string option) list
   | SetStatement of expression * expression
   | BlockStatement of expression * ast
   | MacroStatement of expression * arguments * ast
   | FilterStatement of expression * ast
-  | CallStatement of expression * arguments * arguments * ast
+  | CallStatement of expression * arguments * (string option * expression) list * ast
   | WithStatement of (string * expression) list * ast
   | AutoEscapeStatement of expression * ast
   | NamespaceStatement of string * (string * expression) list
@@ -119,18 +119,16 @@ and expression =
   | GtEqOpExpr of expression * expression
   | DotExpr of expression * string
   | BracketExpr of expression * expression
-  | ApplyExpr of expression * arguments
+  | ApplyExpr of expression * (string option * expression) list
   | ListExpr of expression list
   | SetExpr of expression list
   | ObjExpr of (expression * expression) list
   | TestOpExpr of expression * expression
-  | KeywordExpr of expression * expression
-  | AliasExpr of expression * expression
   | InOpExpr of expression * expression
 
 and with_context = bool
 and branch = expression option * ast
-and arguments = expression list
+and arguments = (string * expression option) list
 (**/**)
 
 (** {[

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -81,7 +81,7 @@ and statement =
     TextStatement of string
   | ExpandStatement of expression
   | IfStatement of branch list
-  | ForStatement of expression * expression * ast
+  | ForStatement of string list * expression * ast
   | IncludeStatement of expression * with_context
   | RawIncludeStatement of expression
   | ExtendsStatement of string

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -97,6 +97,7 @@ and statement =
   | NamespaceStatement of string * (string * expression) list
   | Statements of ast
   | FunctionStatement of expression * arguments * ast
+  | SwitchStatement of expression * (expression list * ast) list
 
 and expression =
     IdentExpr of string

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -122,7 +122,7 @@ and expression =
   | ApplyExpr of expression * (string option * expression) list
   | ListExpr of expression list
   | SetExpr of expression list
-  | ObjExpr of (expression * expression) list
+  | ObjExpr of (string * expression) list
   | TestOpExpr of expression * expression
   | InOpExpr of expression * expression
 

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -92,7 +92,7 @@ and statement =
   | MacroStatement of expression * arguments * ast
   | FilterStatement of expression * ast
   | CallStatement of expression * arguments * arguments * ast
-  | WithStatement of expression list * ast
+  | WithStatement of (string * expression) list * ast
   | AutoEscapeStatement of expression * ast
   | NamespaceStatement of string * (string * expression) list
   | Statements of ast

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -88,15 +88,15 @@ and statement =
   | ImportStatement of string * string option
   | FromImportStatement of string * (string * string option) list
   | SetStatement of expression * expression
-  | BlockStatement of expression * ast
-  | MacroStatement of expression * arguments * ast
-  | FilterStatement of expression * ast
-  | CallStatement of expression * arguments * (string option * expression) list * ast
+  | BlockStatement of string * ast
+  | MacroStatement of string * arguments * ast
+  | FilterStatement of string * ast
+  | CallStatement of string * arguments * (string option * expression) list * ast
   | WithStatement of (string * expression) list * ast
   | AutoEscapeStatement of expression * ast
   | NamespaceStatement of string * (string * expression) list
   | Statements of ast
-  | FunctionStatement of expression * arguments * ast
+  | FunctionStatement of string * arguments * ast
   | SwitchStatement of expression * (expression list * ast) list
 
 and expression =

--- a/tests/test_dead_code_elimination.ml
+++ b/tests/test_dead_code_elimination.ml
@@ -16,7 +16,7 @@ let assert_eq expected source =
 
 let test_0 _ =
   assert_eq
-    [ FunctionStatement ( IdentExpr "foo"
+    [ FunctionStatement ( "foo"
                         , []
                         , [ ExpandStatement (LiteralExpr (Tint 42))
                           ] )

--- a/tests/test_dead_code_elimination.ml
+++ b/tests/test_dead_code_elimination.ml
@@ -43,7 +43,7 @@ let test_2 _ =
 let test_3 _ =
   assert_eq
     [ Statements []
-    ; ForStatement ( SetExpr [ IdentExpr "foo" ]
+    ; ForStatement ( IdentExpr "foo"
                    , IdentExpr "bar"
                    , [ ExpandStatement (ApplyExpr (IdentExpr "foo", []) ) ])
     ]

--- a/tests/test_dead_code_elimination.ml
+++ b/tests/test_dead_code_elimination.ml
@@ -43,7 +43,7 @@ let test_2 _ =
 let test_3 _ =
   assert_eq
     [ Statements []
-    ; ForStatement ( IdentExpr "foo"
+    ; ForStatement ( [ "foo" ]
                    , IdentExpr "bar"
                    , [ ExpandStatement (ApplyExpr (IdentExpr "foo", []) ) ])
     ]

--- a/tests/test_output.ml
+++ b/tests/test_output.ml
@@ -140,6 +140,14 @@ let test_with test_ctxt =
     "tmptmp2hoge"
 ;;
 
+let test_with_2 _test_ctxt =
+  assert_interp_raises
+    "{% with hoge, 'foo', bar %}\
+     {{ hoge }}{{ hige }}\
+     {% endwith %}"
+    Jg_parser.Error
+;;
+
 let test_defined test_ctxt =
   assert_interp ~test_ctxt
     "{% set obj = {age:10, name:'taro'} %}\
@@ -251,6 +259,7 @@ let suite = "runtime test" >::: [
   "test_defined" >:: test_defined;
   "test_is" >:: test_is;
   "test_with" >:: test_with;
+  "test_with_2" >:: test_with_2;
   "test_white_space_control" >:: test_white_space_control;
   "test_invalid_iterable" >:: test_invalid_iterable;
   "test_pprint" >:: test_pprint;

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -611,12 +611,19 @@ let test_min_max _ctx =
 let test_nth _ctx =
   let list = Tlist [Tint 3; Tint 0; Tint 2] in
   let ary = Tarray [| Tint 1; Tint 10; Tint 12 |] in
+  let str1 = Tstr "日本語" in
+  let str2 = Tstr "hoge" in
   assert_equal_tvalue (Tint 3) (jg_nth (Tint 0) list);
   assert_equal_tvalue (Tint 0) (jg_nth (Tint 1) list);
   assert_equal_tvalue (Tint 2) (jg_nth (Tint 2) list);
   assert_equal_tvalue (Tint 1) (jg_nth (Tint 0) ary);
   assert_equal_tvalue (Tint 10) (jg_nth (Tint 1) ary);
-  assert_equal_tvalue (Tint 12) (jg_nth (Tint 2) ary)
+  assert_equal_tvalue (Tint 12) (jg_nth (Tint 2) ary) ;
+  assert_equal_tvalue (Tstr "日") (jg_nth (Tint 0) str1);
+  assert_equal_tvalue (Tstr "本") (jg_nth (Tint 1) str1);
+  assert_equal_tvalue (Tstr "語") (jg_nth (Tint 2) str1);
+  assert_equal_tvalue (Tstr "h") (jg_nth (Tint 0) str2);
+  assert_equal_tvalue (Tstr "e") (jg_nth (Tint 3) str2)
 
 let test_map _ctx =
   let names = unbox_list @@ jg_map Tnull test_persons ~kwargs:[("attribute", Tstr "name")] in


### PR DESCRIPTION
First choice is to switch to menhir instead of ocamlyacc. menhir is just better thant ocamlyacc, and it helped me a lot for reducing the number of conflicts and simplify the writing of rules. I think it totally worth it to add this as a new dependency.

Some `tvalue` unwrapping:  `ForStatement`, `FromImportStatement`, `CallStatement`, `WithStatement` and `ApplyExpr` now uses strings (ident) values instead of tvalues + unwrapping. 

`KeywordExpr` and `AliasExpr` removed from `Jg_types.expression` as they were not really expressions but juste useful for some cases (e.g. macro/function definition/application).

As a side effect, it may avoid the parser to accept programs that will be rejected at runtime, see the removal of `expr -> failwith @@ spf "syntax error: value_of_expr:%s" (show_expression expr)` in `Jg_interp`. I am not sure about this point at all, it is more an intuition that a real reflexion.

Added `%token OPEN_EXPRESSION CLOSE_EXPRESSION` in order to reduce the number of conflicts.
As a consequence, it fixed the state where expressions could be used inside of `{% %}` instead of `{{ }}`. See the fix in example/samples/is.jingoo.

I have some doubt about modifications to `IS` expression case. Also, I feel like `TestOpExpr` should be unified with `ApplyExpr` (i.e. remove `TestOpExpr` and use only `ApplyExpr`), but I did not really think about it yet.

NB: This has not been tested (yet) except with the jingoo's test suite.

Also, I am not sure about commit 126ef6c03d9ccf9e4f83c424e4caac3e6c5437cc