### PR TITLE
Allow repeating macro name in endmacro part.

### DIFF
--- a/example/samples/macro.jingoo
+++ b/example/samples/macro.jingoo
@@ -1,6 +1,7 @@
 {% macro li (content) %}<li>{{ content }}</li>{% endmacro -%}
+{% macro oli (content) %}{{ li (content) }}{% endmacro oli -%}
 <ol>
-  {{ li ('Item1') }}
-  {{ li ('Item2') }}
-  {{ li ('Item3') }}
+  {{ oli ('Item1') }}
+  {{ oli ('Item2') }}
+  {{ oli ('Item3') }}
 </ol>

--- a/example/templates/templates.en.jingoo
+++ b/example/templates/templates.en.jingoo
@@ -130,6 +130,9 @@
             It means that you define two macro with the same name, the second will erase the first,
             <strong>even in the macro invocation occuring before the second definition.</strong>
           </p>
+          <p class="p">
+            Optionally, you can repeat the name of the macro in the {{ code ('endmacro') }} part.
+          </p>
         {% endblock %}
       {% endcall %}
 

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -166,8 +166,8 @@ stmt:
 | RAWINCLUDE expr { pel "raw include sts"; RawIncludeStatement($2) }
 | IMPORT STRING preceded(AS, IDENT)? { pel "import sts"; ImportStatement($2, $3) }
 | FROM STRING IMPORT separated_list(COMMA, alias) { pel "from import sts"; FromImportStatement($2, $4) }
-| MACRO IDENT LPAREN separated_list(COMMA, argument_definition) RPAREN stmt* ENDMACRO
-  { pel "macro sts"; MacroStatement($2, $4, $6) }
+| MACRO IDENT LPAREN separated_list(COMMA, argument_definition) RPAREN stmt* ENDMACRO IDENT?
+  { pel "macro sts"; (match $8 with Some n -> assert ($2 = n) | _ -> ()) ; MacroStatement($2, $4, $6) }
 | FUNCTION IDENT LPAREN separated_list(COMMA, argument_definition) RPAREN stmt* ENDFUNCTION
   { pel "function sts"; FunctionStatement($2, $4, $6) }
 | CALL opt_args IDENT LPAREN separated_list(COMMA, argument_application) RPAREN stmt* ENDCALL


### PR DESCRIPTION
I use to add a comment at the end of my macros, so I do not have to jump to the `{% macro ... %}` statement to remember the name of what I am looking at when it does not fit in one screen. It might help to allow the `endmacro` to take the name of the macro being defined as label.

It can also be used as an extra security to be sure to be closing the good macro.