### PR TITLE
Parser: auto trimming TEXT just after SWITCH token.

### DIFF
--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -185,10 +185,12 @@ stmt:
   }
 | SWITCH
   e=expr
+  ws=TEXT?
   cases=preceded(CASE, pair(expr, stmt*))*
   default=preceded(DEFAULT, stmt*)?
   ENDSWITCH
   {
+    (match ws with Some s -> assert (String.trim s = "") | None -> ()) ;
     let rec extract = function
       | OrOpExpr (e1, e2) -> extract e1 @ extract e2
       | e -> [e] in


### PR DESCRIPTION
This would fix a problem where.

```
{% switch foo %}
  {% case 1 %}
```

would fail.

You actually need to use

```
{% switch foo %}
  {%- case 1 %}
```
or
```
{% switch foo -%}
  {% case 1 %}
```

Nothing should appear between `SWITCH` and `CASE` because it makes no sens.
That being said, I am not sure if jingoo should automatically trim the user input or fail with a comprehensible error message so the user can easily fix its input.