### PR TITLE
Improved error messages.

### DIFF
--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -87,7 +87,7 @@ let rec value_of_expr env ctx = function
     let kwargs = kwargs_of_app env ctx args in
     let callable = value_of_expr env ctx expr in
     (match callable with
-    | Tfun _ -> jg_apply callable nargs ~kwargs ~name
+    | Tfun _ -> jg_apply callable nargs ~kwargs
     | _ ->
       (match jg_get_macro ctx name with
        | Some macro -> ignore @@ eval_macro env ctx name nargs kwargs macro; Tnull

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -168,13 +168,12 @@ let jg_escape_html str =
     | other -> Tstr(Jg_utils.escape_html @@ string_of_tvalue other)
 
 (**/**)
-let jg_apply ?(name="<lambda>") ?kwargs f args =
+let jg_apply ?kwargs f args =
   if args = [] then
     let fn = unbox_fun f in
     Tfun (fun ?kwargs:kw x -> fn ?kwargs:(merge_kwargs kwargs kw) x)
   else
-    try List.fold_left (fun fn a -> (unbox_fun fn) ?kwargs a) f args
-    with _ -> func_failure ~name ?kwargs args
+    List.fold_left (fun fn a -> (unbox_fun fn) ?kwargs a) f args
 
 let jg_apply_filters ?(autoescape=true) ?(safe=false) ctx text filters =
   let (safe, text) = List.fold_left (fun (safe, text) name ->
@@ -183,7 +182,7 @@ let jg_apply_filters ?(autoescape=true) ?(safe=false) ctx text filters =
     else if name = "escape" && autoescape = true then
       (safe, text)
     else
-      (safe, jg_apply (jg_get_func ctx name) [text] ~name)
+      (safe, jg_apply (jg_get_func ctx name) [text])
   ) (safe, text) filters in
   if safe || not autoescape then text else jg_escape_html text
 

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -275,17 +275,17 @@ let func_no_kw ?name f n =
     let rec aux acc rem =
       Tfun
         (fun ?(kwargs=[]) x ->
-           if kwargs <> [] then func_failure ?name (List.rev @@ x :: acc)
+           if kwargs <> [] then func_failure ?name ~kwargs (List.rev @@ x :: acc)
            else if rem = 1 then f (List.rev @@ x :: acc)
            else aux (x :: acc) (rem - 1))
     in
     aux [] n
 
 let func_arg1_no_kw ?name f =
-  func_no_kw (function [ a ] -> f a | args -> func_failure ?name args) 1
+  func_no_kw ?name (function [ a ] -> f a | args -> func_failure ?name args) 1
 
 let func_arg2_no_kw ?name f =
-  func_no_kw (function [ a ; b ] -> f a b | args -> func_failure ?name args) 2
+  func_no_kw ?name (function [ a ; b ] -> f a b | args -> func_failure ?name args) 2
 
 let func_arg3_no_kw ?name f =
-  func_no_kw (function [ a ; b ; c ] -> f a b c | args -> func_failure ?name args) 3
+  func_no_kw ?name (function [ a ; b ; c ] -> f a b c | args -> func_failure ?name args) 3

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -724,19 +724,19 @@ let test_func_arg1 _ctx =
   let jg_to_mail_bad = func_arg1_no_kw ~name:"to_mail_bad" (to_mail ~defaults:[("domain", Tstr "gmail.com")]) in
 
   assert_equal_tvalue
-    (jg_apply ~name:"to_mail"
+    (jg_apply
        ~kwargs:[("domain", Tstr "hotmail.com")]
        jg_to_mail [Tstr "foo"])
     (Tstr "foo@hotmail.com");
 
   assert_equal_tvalue
-    (jg_apply ~name:"to_mail_ex"
+    (jg_apply
        ~kwargs:[]
        jg_to_mail_bad [Tstr "foo"])
     (Tstr "foo@gmail.com");
 
   assert_raises (Failure "type error: to_mail_bad(domain=string,string)")
-    (fun _ -> ignore (jg_apply ~name:"to_mail_bad"
+    (fun _ -> ignore (jg_apply
                         ~kwargs:[("domain", Tstr "hotmail.com")]
                         jg_to_mail_bad [Tstr "foo"]))
 


### PR DESCRIPTION
<strike>
```jinja2
{% macro aux (x) %}
   {% set ns = namespace (mark='') %}
   <li><ul>
   {% for x in x %}
     {% set ns.mark += 'x' %}
     <li>{{ ns.mark }} {{ x.name }}: {{ x.value }}</li>
   {% endfor %}
   </li></ul>
{% endmacro %}

{%- set ns = namespace (cnt = 0) -%}

<ul>
  {%- for g in list -%}
    {{ aux (g) }}
    {%- set ns.cnt = ns.cnt + 1 -%}
  {%- endfor-%}
</ul>

<p>Number of elements: {{ ns.cnt }}</p>
```

The last line will produce `<p>Number of elements: </p>`.

Current implementation silently erase any existing namespace, which is likely to produce very strange errors in case of nested macro/function calls.

This PR propose to disallow this, because it is really likely to: at best create errors, at worst corrupt or leak data.

A failure is now raised to prevent this an make the author correct its namespace name.
</strike>

Also, I removed the exception catching in `jg_apply` because it hide useful information, and it is likely to print a useless message talking about `type error` which was not the case in 100% of my recent cases.