### PR TITLE
Update opam's build instructions

### DIFF
--- a/jingoo.opam
+++ b/jingoo.opam
@@ -6,8 +6,7 @@ bug-reports: "https://github.com/tategakibunko/jingoo/issues"
 dev-repo: "git+https://github.com/tategakibunko/jingoo.git"
 license: "BSD-3-Clause"
 synopsis: "Template engine almost compatible with Jinja2(python template engine)"
-build: [make "all"]
-install: [make "install"]
+build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
   "ocaml" {>= "4.04.0"}
   "dune" {>= "1.4.0"}


### PR DESCRIPTION
See ocaml/opam-repository#15508 - without this, builds of jingoo might try to build outside of opam's sandbox.