### PR TITLE
Add support for capturing a block's output into a variable.

### DIFF
--- a/example/samples/set_block.expected
+++ b/example/samples/set_block.expected
@@ -1,0 +1,18 @@
+Stored output:
+<ol>
+  <li>Item1</li>
+  <li>Item2</li>
+  <li>Item3</li>
+  <li>&#60;Escaping works&#62;</li>
+</ol>
+
+Variables defined inside block are not exposed:
+
+
+Stored output again:
+<ol>
+  <li>Item1</li>
+  <li>Item2</li>
+  <li>Item3</li>
+  <li>&#60;Escaping works&#62;</li>
+</ol>

--- a/example/samples/set_block.jingoo
+++ b/example/samples/set_block.jingoo
@@ -1,0 +1,19 @@
+{%- set list -%}
+{%- macro li (content) %}<li>{{ content }}</li>{% endmacro -%}
+{%- set item4 = '<Escaping works>' -%}
+<ol>
+  {{ li ('Item1') }}
+  {{ li ('Item2') }}
+  {{ li ('Item3') }}
+  {{ li (item4) }}
+</ol>
+{%- endset -%}
+
+Stored output:
+{{ list }}
+
+Variables defined inside block are not exposed:
+{{ item4 }}
+
+Stored output again:
+{{ list }}

--- a/example/templates/templates.en.jingoo
+++ b/example/templates/templates.en.jingoo
@@ -208,6 +208,9 @@
         {% endblock %}
       {% endcall %}
 
+      {% call section ([ 'Statements', 'Variable assignment', 'Block capture' ], 'set_block', false) %}
+      {% endcall %}
+
       {% call section ([ 'Statements', 'Whitespace control' ], 'whitespace-control', false) %}
         <p class="p">Use {{ code ('{%-') }} to strip whitespaces <strong>before</strong> this token.</p>
         <p class="p">Use {{ code ('-%}') }} to strip whitespaces <strong>after</strong> this token.</p>

--- a/example/test.ml
+++ b/example/test.ml
@@ -74,6 +74,7 @@ let test jingoo_f =
       prerr_endline @@ expected ;
       prerr_endline @@ "--- Got: " ;
       prerr_endline @@ res ;
+      status := 1
   with e ->
     prerr_endline @@ "--- Failure: " ^ jingoo_f ;
     prerr_endline @@ Printexc.to_string e ;

--- a/src/jg_ast_mapper.ml
+++ b/src/jg_ast_mapper.ml
@@ -79,6 +79,9 @@ and statement self stmt : statement = match stmt with
   | SetStatement (e1, e2) ->
     SetStatement (self.expression self e1, self.expression self e2)
 
+  | SetBlockStatement (n, ast) ->
+    SetBlockStatement (n, self.ast self ast)
+
   | BlockStatement (n, ast) ->
     BlockStatement (n, self.ast self ast)
 

--- a/src/jg_ast_optimize.ml
+++ b/src/jg_ast_optimize.ml
@@ -28,6 +28,12 @@ let dead_code_elimination stmts =
     | SetStatement (id, _) as s ->
       maybe_set id ;
       default_mapper.statement self s
+    | SetBlockStatement (id, _) as s ->
+      set_local id;
+      push_block id;
+      let s = default_mapper.statement self s in
+      pop_block () ;
+      s
     | ForStatement (ids, _, _) as s ->
       push_block "" ;
       List.iter set_local ids ;

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -215,6 +215,7 @@ and main_bis = parse
   | "from" as s { token_or_str (s, FROM) main lexbuf }
   | "in" as s { token_or_str (s, IN) main lexbuf }
   | "set" as s { token_or_str (s, SET) main lexbuf }
+  | "endset" as s { token_or_str (s, ENDSET) main lexbuf }
   | "not" as s { token_or_str (s, NOT) main lexbuf }
   | "is" as s { token_or_str (s, IS) main lexbuf }
   | "with" as s { token_or_str (s, WITH) main lexbuf }

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -22,6 +22,7 @@
 %token ENDFOR
 %token IN
 %token SET
+%token ENDSET
 %token EXTENDS
 %token INCLUDE
 %token MACRO
@@ -160,6 +161,10 @@ stmt:
        assert ($4 = None) ;
        pel "set sts";
        SetStatement (SetExpr idents, exprs)
+  }
+| SET IDENT stmt* ENDSET
+  { pel "set_block";
+    SetBlockStatement($2, $3)
   }
 | EXTENDS STRING { pel "extends sts"; ExtendsStatement($2) }
 | BLOCK IDENT stmt* ENDBLOCK { pel "block sts2"; BlockStatement($2, $3) }

--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -85,6 +85,7 @@ let rec string_of_tvalue ?(default = "") = function
   | Tarray _ -> "<array>"
   | Tlazy _ -> "<lazy>"
   | Tvolatile _ -> "<volatile>"
+  | Tsafe x -> x
 
 and string_of_obj default obj =
   string_of_tvalue ~default @@ jg_obj_lookup obj "__str__"
@@ -164,8 +165,9 @@ let jg_nth i value =
 (** [jg_escape_html x] escape [x] string representation using {!Jg_utils.escape_html} *)
 let jg_escape_html str =
   match str with
-    | Tstr str -> Tstr(Jg_utils.escape_html str)
-    | other -> Tstr(Jg_utils.escape_html @@ string_of_tvalue other)
+  | Tsafe str -> Tstr str
+  | Tstr str -> Tstr(Jg_utils.escape_html str)
+  | other -> Tstr(Jg_utils.escape_html @@ string_of_tvalue other)
 
 (**/**)
 let jg_apply ?kwargs f args =
@@ -354,6 +356,7 @@ let rec jg_is_true = function
   | Tarray a -> Array.length a > 0
   | Tlazy fn -> jg_is_true (Lazy.force fn)
   | Tvolatile fn -> jg_is_true (fn ())
+  | Tsafe x -> x <> ""
 
 let jg_not x =
   Tbool (not (jg_is_true x))

--- a/src/jg_types.ml
+++ b/src/jg_types.ml
@@ -54,6 +54,7 @@ and tvalue =
   | Tarray of tvalue array
   | Tlazy of tvalue Lazy.t
   | Tvolatile of (unit -> tvalue)
+  | Tsafe of string
 [@@deriving show { with_path = false }]
 
 and kwargs = (string * tvalue) list
@@ -72,6 +73,7 @@ and statement =
   | ImportStatement of string * string option
   | FromImportStatement of string * (string * string option) list
   | SetStatement of expression * expression
+  | SetBlockStatement of string * ast
   | BlockStatement of string * ast
   | MacroStatement of string * arguments * ast
   | FilterStatement of string * ast
@@ -156,6 +158,7 @@ let type_string_of_tvalue = function
   | Tarray _ -> "array"
   | Tlazy _ -> "lazy"
   | Tvolatile _ -> "volatile"
+  | Tsafe _ -> "safe"
 
 let invalid_argument x name =
   raise @@ Invalid_argument (name ^ ":" ^ type_string_of_tvalue x)

--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -70,6 +70,7 @@ and tvalue =
   | Tarray of tvalue array
   | Tlazy of tvalue Lazy.t
   | Tvolatile of (unit -> tvalue)
+  | Tsafe of string
 
 and kwargs = (string * tvalue) list
 
@@ -88,6 +89,7 @@ and statement =
   | ImportStatement of string * string option
   | FromImportStatement of string * (string * string option) list
   | SetStatement of expression * expression
+  | SetBlockStatement of string * ast
   | BlockStatement of string * ast
   | MacroStatement of string * arguments * ast
   | FilterStatement of string * ast


### PR DESCRIPTION
This matches jinja2 2.8's {% set variable %}block of data{% endset %}.