### PR TITLE
Raise errors when macro gets called with unknown arguments.

### DIFF
--- a/example/samples/function.expected
+++ b/example/samples/function.expected
@@ -17,3 +17,4 @@ add_val(val=-2,-1) = -3
 add_val(val=-2,0) = -2
 add_val(val=-2,1) = -1
 add_val(val=-2,2) = 0
+const() = 4

--- a/example/samples/function.jingoo
+++ b/example/samples/function.jingoo
@@ -27,3 +27,7 @@ inv(reverse=true,'a','b').a = {{ (inv(reverse=true,'a','b')).a }}
 {% for x in [-1,0,1,2] | map (add_val, val=-2) -%}
   add_val(val=-2,{{x[0]}}) = {{x[1]}}
 {% endfor -%}
+
+{% function const () -%}{{ 4 }}{% endfunction -%}
+
+const() = {{ const () }}

--- a/example/samples/macro.expected
+++ b/example/samples/macro.expected
@@ -2,4 +2,5 @@
   <li>Item1</li>
   <li>Item2</li>
   <li>Item3</li>
+  <li>Item4</li>
 </ol>

--- a/example/samples/macro.jingoo
+++ b/example/samples/macro.jingoo
@@ -1,7 +1,9 @@
 {% macro li (content) %}<li>{{ content }}</li>{% endmacro -%}
 {% macro oli (content) %}{{ li (content) }}{% endmacro oli -%}
+{% macro const () %}{{ oli('Item4') }}{% endmacro -%}
 <ol>
   {{ oli ('Item1') }}
   {{ oli ('Item2') }}
   {{ oli ('Item3') }}
+  {{ const () }}
 </ol>

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -83,11 +83,12 @@ let rec value_of_expr env ctx = function
 
   | ApplyExpr(expr, args) ->
     let name = apply_name_of expr in
-    let nargs = if args = [] then [ Tnull ] else nargs_of env ctx args in
+    let nargs = nargs_of env ctx args in
+    let nargs_fun = if args = [] then [ Tnull ] else nargs in
     let kwargs = kwargs_of_app env ctx args in
     let callable = value_of_expr env ctx expr in
     (match callable with
-    | Tfun _ -> jg_apply callable nargs ~kwargs
+    | Tfun _ -> jg_apply callable nargs_fun ~kwargs
     | _ ->
       (match jg_get_macro ctx name with
        | Some macro -> ignore @@ eval_macro env ctx name nargs kwargs macro; Tnull
@@ -282,7 +283,7 @@ and eval_statement env ctx = function
       let value = ref Tnull in
       let ctx = { ctx with serialize = true ; output = fun x -> value := x } in
       let ctx = jg_push_frame ctx in
-      ignore (jg_eval_aux ctx args kwargs macro @@ fun ctx ast ->
+      ignore (jg_eval_aux ctx name args kwargs macro @@ fun ctx ast ->
               List.fold_left (eval_statement env) ctx ast) ;
       !value
     in


### PR DESCRIPTION
This will cause us to raise if
- a macro receives more anonymous arguments than it expects
- a macro receives a keyword argument that it does not expect

This helps people that move over from jinja2 to not have their
templates silently misbehave where they used to pass in positional
arguments for arguments that are defined with a default value.
e.g.
{% macro test(a=False, b=False) %} ... {% endmacro %}
{{ test(True, True) }}