### PR TITLE
Interface for loading templates for multiple evaluations.

### DIFF
--- a/src/jg_template.ml
+++ b/src/jg_template.ml
@@ -32,3 +32,17 @@ let from_chan = content (Jg_interp.from_chan ?file_path:None)
 let from_file = content Jg_interp.from_file
 
 let from_string = content (Jg_interp.from_string ?file_path:None)
+
+module Loaded = struct
+  type t = Jg_interp.Loaded.t
+
+  let from_chan ?env chan = Jg_interp.Loaded.from_chan ?env chan
+  let from_file ?env file_name = Jg_interp.Loaded.from_file ?env file_name
+  let from_string ?env source = Jg_interp.Loaded.from_string ?env source
+
+  let eval ?ctx ?(models=[]) t =
+    let buffer = Buffer.create 1024 in
+    let output x = Buffer.add_string buffer (Jg_runtime.string_of_tvalue x) in
+    let () = Jg_interp.Loaded.eval t ~models ~output ?ctx () in
+    Buffer.contents buffer
+end

--- a/src/jg_template.mli
+++ b/src/jg_template.mli
@@ -17,7 +17,7 @@ val from_file :
     return result string.
 
     [env] is environment parameters defined in Jg_types.environment.
-    enviroment parametors consist of template_dirs, autoescape_flag etc.
+    environment parameters consist of template_dirs, autoescape_flag etc.
 
     default of [ctx] is None.
 
@@ -50,3 +50,40 @@ val from_string :
 
     nomally, this context is used internal parsing.
 *)
+
+module Loaded : sig
+  type t
+  (** A [Loaded.t] stores a parsed template in memory so it can be evaluated
+      multiple times against different models more efficiently. *)
+
+  val from_file : ?env:environment -> string -> t
+  (** [from_file env template_filename]
+      return result t.
+
+      [env] is environment parameters defined in Jg_types.environment.
+      environment parameters consist of template_dirs, autoescape_flag etc.
+  *)
+
+  val from_chan : ?env:environment -> in_channel -> t
+  (** [from_chan env chan]
+      return result t.
+
+      same as from_file but read template from {!type:Stdlib.in_channel}.
+  *)
+
+  val from_string : ?env:environment -> string -> t
+  (** [from_string env source_string]
+      return result t.
+
+      same as from_file but read template from source string.
+  *)
+
+  val eval : ?ctx:context -> ?models:(string * tvalue) list -> t -> string
+  (** [eval context models t] evaluates the loaded template in the given context
+      with the given models.
+      return result string.
+
+      [models] is variable table for template. for example,
+      [("msg", Tstr "hello, world!"); ("count", Tint 100); ]
+  *)
+end


### PR DESCRIPTION
Add a new module to the Jg_template interface which allows one to
store a parsed template in memory so it can be evaluated multiple
times against different models more efficiently.