### PR TITLE
Set statement

### DIFF
--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -168,7 +168,7 @@ and eval_statement env ctx = function
     )
 
   | SetStatement(DotExpr(IdentExpr ns, v), expr) ->
-    Hashtbl.add
+    Hashtbl.replace
       (Hashtbl.find ctx.namespace_table ns) v (value_of_expr env ctx expr) ;
     ctx
 

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -172,6 +172,13 @@ and eval_statement env ctx = function
       (Hashtbl.find ctx.namespace_table ns) v (value_of_expr env ctx expr) ;
     ctx
 
+  | SetStatement(BracketExpr(IdentExpr ns, k), expr) ->
+    Hashtbl.replace
+      (Hashtbl.find ctx.namespace_table ns)
+      (match value_of_expr env ctx k with Tstr k -> k | _ -> assert false)
+      (value_of_expr env ctx expr) ;
+    ctx
+
   | SetBlockStatement(name, ast) ->
     let macro = Macro ([], [], ast) in
     let apply macro =

--- a/src/jg_parser.mly
+++ b/src/jg_parser.mly
@@ -135,6 +135,18 @@ stmt:
     | Some MOD -> SetStatement (k, ModOpExpr(k, $7))
     | Some _ -> assert false
   }
+| SET ident LBRACKET expr RBRACKET set_operator? EQ expr
+  { pel "set";
+    let k = BracketExpr ($2, $4) in
+    match $6 with
+    | None -> SetStatement (k, $8)
+    | Some PLUS -> SetStatement (k, PlusOpExpr(k, $8))
+    | Some MINUS -> SetStatement (k, MinusOpExpr(k, $8))
+    | Some TIMES -> SetStatement (k, TimesOpExpr(k, $8))
+    | Some DIV -> SetStatement (k, DivOpExpr(k, $8))
+    | Some MOD -> SetStatement (k, ModOpExpr(k, $8))
+    | Some _ -> assert false
+  }
 | SET ident preceded(COMMA, ident)* set_operator? EQ expr
   {
     pel "set";


### PR DESCRIPTION
Add support for `{% set ns [ k ] = x %}` which is the same as `{% set ns.k = x %}` but with `k` being an expression instead of a string.

I use it to use namespaces as hash tables, I do not know if is it hackish of it is a real feature.

It probably won't help a lot, but this is a code I actually use in order to traverse a data structure and build some kind of index.

```jingoo
{%- set RELATION_CHOICE_NS = namespace () -%}

{%- for m in M.data -%}
  {%- for p, n in m.data -%}
    {%- if p.first_name != "?" && p.surname != "?" -%}
      {%- set x = RELATION_CHOICE_NS [p.iper] -%}
      {%- if x -%}
        {%- set RELATION_CHOICE_NS [p.iper] =
                [ x[0], x[1] + 1,   x[2],  x[3]
                , (m.x1 && not (m.x1 in x[4]) ? [m.x1] + x[4] : x[4])
                , (m.x2 && not (m.x2 in x[5]) ? [m.x2] + x[4] : x[5]) ] -%}
      {%- else -%}
        {%- set RELATION_CHOICE_NS [p.iper] =
                [ p, 1, m.pp1, m.pp2, (m.x1 ? [m.x1] : []), (m.x2 ? [m.x2] : []) ] -%}
      {%- endif -%}
    {%- endif -%}
  {%- endfor -%}
{%- endfor -%}
```