### PR TITLE
jg_init_context: used Hashtbl.replace instead of add so you won't waste space

### DIFF
--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -1576,7 +1576,7 @@ let jg_init_context ?(models=(fun _ -> Tnull)) output env =
     serialize = false;
     output
   } in
-  Array.iter (fun (n, v) -> Hashtbl.add top_frame n v) std_filters;
-  List.iter (fun (n, v) -> Hashtbl.add top_frame n v) env.filters;
+  Array.iter (fun (n, v) -> Hashtbl.replace top_frame n v) std_filters;
+  List.iter (fun (n, v) -> Hashtbl.replace top_frame n v) env.filters;
   Hashtbl.add top_frame "jg_is_autoescape" (Tbool env.autoescape);
   ctx


### PR DESCRIPTION
This is insignificant, but it is useless to use add instead of replace.