### PR TITLE
implemented urlencode for str, iterable(mapping is not yet)

### DIFF
--- a/src/jg_runtime.ml
+++ b/src/jg_runtime.ml
@@ -1588,6 +1588,14 @@ let jg_test_sequence target =
 let jg_test_string target =
   jg_strp target
 
+(** [jg_urlencode x] returns url encoded string of [x] *)
+let rec jg_urlencode = function
+  | Tstr str -> Tstr (Jg_utils.encode_url str)
+  | Tlist list -> Tlist (List.map jg_urlencode list)
+  | Tarray ary -> Tarray (Array.map jg_urlencode ary)
+  | Tset set -> Tset (List.map jg_urlencode set)
+  | other -> failwith_type_error_1 "jg_urlencode" other
+  
 (** [func_arg1] (Deprecated)
     Link to Jg_types.func_arg1 to keep backward compatibility for jingoo(<= 1.2.21).
     Use Jg_types.func_arg1 instead for jingoo(>= 1.3.0)
@@ -1638,6 +1646,7 @@ let std_filters = [|
   ("pprint", func_arg1_no_kw jg_pprint);
   ("flatten", func_arg1_no_kw jg_flatten);
   ("safe", func_arg1_no_kw jg_safe);
+  ("urlencode", func_arg1_no_kw jg_urlencode);
 
   ("attr", func_arg2_no_kw jg_attr);
   ("batch", func_arg2 (jg_batch ?defaults:None));

--- a/tests/test_runtime.ml
+++ b/tests/test_runtime.ml
@@ -32,6 +32,10 @@ let test_escape _ctx =
     (Tstr "Lo&amp;rem&gt;\n I&lt;ps&quot;um")
     (jg_escape_html (Tstr "Lo&rem>\n I<ps\"um"))
 
+let test_urlencode _ctx =
+  assert_equal_tvalue (Tstr "http%3A//example.com/foo+bar") (jg_urlencode (Tstr "http://example.com/foo bar"));
+  assert_equal_tvalue (Tstr "http%3A//example.com/tag/%E5%B1%B1") (jg_urlencode (Tstr "http://example.com/tag/山"))
+
 let test_string_of_tvalue _ctx =
   assert_equal "a" (string_of_tvalue (Tstr "a"));
   assert_equal "1" (string_of_tvalue (Tint 1));
@@ -805,6 +809,7 @@ let test_tojson _ctx =
 
 let suite = "runtime test" >::: [
   "test_escape" >:: test_escape;
+  "test_urlencode" >:: test_urlencode;
   "test_string_of_tvalue" >:: test_string_of_tvalue;
   "test_plus" >:: test_plus;
   "test_minus" >:: test_minus;


### PR DESCRIPTION
I didn't find the urlencode filter necessary for Mapping format data, so it still only supports strings and iterables.