### PR TITLE
Remove unnecessary `with_path` argument from deriving show in signature

### DIFF
--- a/src/jg_types.mli
+++ b/src/jg_types.mli
@@ -76,7 +76,7 @@ and kwargs = (string * tvalue) list
 
 (**/**)
 and ast = statement list
-[@@deriving show { with_path = false }]
+[@@deriving show]
 
 and statement =
     TextStatement of string


### PR DESCRIPTION
The deriving argument has no effect in a signature.

This was revealed by https://github.com/ocaml/opam-repository/pull/25458#issuecomment-1992006886.