### PR TITLE
Improve parsing exception message errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tests/dune
 example/dune
 example/templates/dune
 example/.merlin
+_opam/

--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -368,12 +368,12 @@ and ast_from_lexbuf filename lexbuf =
   let ast = Jg_parser.input (Jg_lexer.main ctx) lexbuf in
   ast
 
-and error e lexbuf =
+and synerror lexbuf =
   let curr = lexbuf.Lexing.lex_curr_p in
   let l = curr.Lexing.pos_lnum in
   let c = curr.Lexing.pos_cnum - curr.Lexing.pos_bol in
   let t = Lexing.lexeme lexbuf in
-  let msg = Printf.sprintf "Error line %d, col %d, token %s (%s)" l c t e in
+  let msg = Printf.sprintf "Error line %d, col %d, token %s" l c t in
   raise (SyntaxError msg)
 
 and ast_from_chan filename ch =
@@ -383,12 +383,9 @@ and ast_from_chan filename ch =
     close_in ch;
     ast
   with
-  | SyntaxError e ->
-    close_in ch ;
-    error e lexbuf
   | Jg_parser.Error ->
     close_in ch ;
-    error "" lexbuf
+    synerror lexbuf
 
 and ast_from_file ~env filename =
   let filename = get_file_path env filename in
@@ -398,7 +395,9 @@ and ast_from_file ~env filename =
 and ast_from_string string =
   let lexbuf = Lexing.from_string string in
   try ast_from_lexbuf None lexbuf
-  with SyntaxError e -> error e lexbuf
+  with
+  | Jg_parser.Error ->
+    synerror lexbuf
 
 (* Remove macros from ast and return a list of them. *)
 let extract_macros env stmts =

--- a/src/jg_utils.ml
+++ b/src/jg_utils.ml
@@ -231,7 +231,7 @@ let get_parser_error exn lexbuf =
   let fname = curr.Lexing.pos_fname in
   let line = curr.Lexing.pos_lnum in
   let tok = Lexing.lexeme lexbuf in
-  let msg = match exn with Jg_types.SyntaxError msg -> msg | _ -> Printexc.to_string exn in
+  let msg = Printexc.to_string exn in
   Printf.sprintf "%s: '%s' at line %d in file %s" msg tok line fname
 
 let read_file_as_string filename =

--- a/tests/test_output.ml
+++ b/tests/test_output.ml
@@ -152,7 +152,7 @@ let test_with_2 _test_ctxt =
     "{% with hoge, 'foo', bar %}\
      {{ hoge }}{{ hige }}\
      {% endwith %}"
-    Jg_parser.Error
+    (Jg_types.SyntaxError "Error line 1, col 12, token ,")
 ;;
 
 let test_defined test_ctxt =


### PR DESCRIPTION
In case of template parsing failure, we currently raise a meaningless Menhir Error. The current error handling seems outdated, and wrap the message for the SyntaxError. But we we don't raise this anymore.

Catch the Menhir error, and raise a SyntaxError instead.

Also embark a tiny gitignore change to ignore `_opam` folder, for opam locals witches.

Solve: https://github.com/tategakibunko/jingoo/issues/140