### PR TITLE
Fix multiple error report position issues

### DIFF
--- a/src/jg_interp.ml
+++ b/src/jg_interp.ml
@@ -369,9 +369,9 @@ and ast_from_lexbuf filename lexbuf =
   ast
 
 and synerror lexbuf =
-  let curr = lexbuf.Lexing.lex_curr_p in
+  let curr = lexbuf.Lexing.lex_start_p in
   let l = curr.Lexing.pos_lnum in
-  let c = curr.Lexing.pos_cnum - curr.Lexing.pos_bol in
+  let c = curr.Lexing.pos_cnum - curr.Lexing.pos_bol + 1 in
   let t = Lexing.lexeme lexbuf in
   let msg = Printf.sprintf "Error line %d, col %d, token %s" l c t in
   raise (SyntaxError msg)

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -132,7 +132,8 @@ and main_bis ctx = parse
       | "" -> main ctx lexbuf
       | content -> TEXT content
   }
-  | ("{{" | (blank | newline)* "{{-") {
+  | ("{{" | (blank | newline)* "{{-") as str {
+    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str;
     if ctx.mode = `Logic then fail lexbuf @@ "Unexpected '{{' token" ;
     update_context ctx `Logic (Some "}}");
     (* print_endline @@ spf "text:%s" (Buffer.contents buf); *)
@@ -150,6 +151,7 @@ and main_bis ctx = parse
     main ctx lexbuf
   }
   | ("}}" | "-}}" (blank | newline)*) as str {
+    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str;
     match ctx.terminator with
       | None ->
 	add_str ctx str; main ctx lexbuf

--- a/src/jg_lexer.mll
+++ b/src/jg_lexer.mll
@@ -35,14 +35,26 @@
     spf "File '%s', line %d, char %d: %s" pos_fname pos_lnum (pos_cnum - pos_bol) str
 
   let init_lexer_pos fname lexbuf =
-    let curr = lexbuf.Lexing.lex_curr_p in
     let pos : Lexing.position = {
       Lexing.pos_fname = (match fname with Some fname -> fname | _ -> "");
       Lexing.pos_lnum = 1;
-      Lexing.pos_bol = curr.Lexing.pos_lnum;
+      Lexing.pos_bol = 0;
       Lexing.pos_cnum = 0
     } in
     lexbuf.Lexing.lex_curr_p <- pos
+
+  let crawl_new_line str lexbuf =
+      String.iteri (fun i c ->
+      match c with
+        | '\n' ->
+          let lsp = lexbuf.Lexing.lex_start_p in
+          let lcp = lexbuf.Lexing.lex_curr_p in
+          lexbuf.Lexing.lex_curr_p <-
+            { lcp with
+              pos_lnum = lcp.pos_lnum + 1;
+              pos_bol = lsp.pos_cnum + i + 1;
+            }
+        | _ -> () ) str
 
   let update_context ctx mode terminator =
     let token_required =
@@ -121,11 +133,11 @@ and main_bis ctx = parse
   | ("{%" | (blank | newline)* "{%-")
        blank* "raw" blank*
      ("%}" | "-%}" (blank | newline)*) as str {
-    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str;
+    crawl_new_line str lexbuf ;
     raw ctx lexbuf
   }
   | ("{%" | (blank | newline)* "{%-") as str {
-    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str;
+    crawl_new_line str lexbuf ;
     if ctx.mode = `Logic then fail lexbuf @@ "Unexpected '{%' token" ;
     update_context ctx `Logic (Some "%}");
     match get_buf ctx with
@@ -133,7 +145,7 @@ and main_bis ctx = parse
       | content -> TEXT content
   }
   | ("{{" | (blank | newline)* "{{-") as str {
-    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str;
+    crawl_new_line str lexbuf ;
     if ctx.mode = `Logic then fail lexbuf @@ "Unexpected '{{' token" ;
     update_context ctx `Logic (Some "}}");
     (* print_endline @@ spf "text:%s" (Buffer.contents buf); *)
@@ -151,7 +163,7 @@ and main_bis ctx = parse
     main ctx lexbuf
   }
   | ("}}" | "-}}" (blank | newline)*) as str {
-    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str;
+    crawl_new_line str lexbuf ;
     match ctx.terminator with
       | None ->
 	add_str ctx str; main ctx lexbuf
@@ -161,7 +173,7 @@ and main_bis ctx = parse
       | _ -> fail lexbuf @@ spf "syntax error '%s'" str
   }
   | ("%}" | "-%}" (blank | newline)*) as str {
-    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str ;
+    crawl_new_line str lexbuf ;
     match ctx.terminator with
       | None ->
 	add_str ctx str; main ctx lexbuf
@@ -293,7 +305,7 @@ and raw ctx = parse
   | ("{%" | (blank | newline)* "{%-")
       blank* "endraw" blank*
     ("%}" | "-%}" (blank | newline)*) as str {
-    String.iter (function '\n' -> Lexing.new_line lexbuf | _ -> () ) str ;
+    crawl_new_line str lexbuf ;
     TEXT (get_buf ctx)
   }
   | _ as c {

--- a/tests/test_output.ml
+++ b/tests/test_output.ml
@@ -152,7 +152,33 @@ let test_with_2 _test_ctxt =
     "{% with hoge, 'foo', bar %}\
      {{ hoge }}{{ hige }}\
      {% endwith %}"
-    (Jg_types.SyntaxError "Error line 1, col 12, token ,")
+    (Jg_types.SyntaxError "Error line 1, col 13, token ,")
+;;
+
+let test_location_1 _test_ctxt =
+  assert_interp_raises
+    "{{ 'foo' for }}"
+    (Jg_types.SyntaxError "Error line 1, col 10, token for")
+;;
+
+let test_location_2 _test_ctxt =
+  assert_interp_raises
+    "\n{{ 'foo' for }}"
+    (Jg_types.SyntaxError "Error line 2, col 10, token for")
+;;
+
+let test_location_3 _test_ctxt =
+  assert_interp_raises
+    "super long line\n\
+     {{-}}"
+    (Jg_types.SyntaxError "Error line 2, col 4, token }}")
+;;
+
+let test_location_4 _test_ctxt =
+  assert_interp_raises
+    "super {{ 'long' -}}\n\
+     {{}}line"
+    (Jg_types.SyntaxError "Error line 2, col 3, token }}")
 ;;
 
 let test_defined test_ctxt =
@@ -287,6 +313,10 @@ let suite = "runtime test" >::: [
   "test_is" >:: test_is;
   "test_with" >:: test_with;
   "test_with_2" >:: test_with_2;
+  "test_location_1" >:: test_location_1;
+  "test_location_2" >:: test_location_2;
+  "test_location_3" >:: test_location_3;
+  "test_location_4" >:: test_location_4;
   "test_white_space_control" >:: test_white_space_control;
   "test_invalid_iterable" >:: test_invalid_iterable;
   "test_pprint" >:: test_pprint;


### PR DESCRIPTION
There was multiple problems with reporting syntax error positions, and this address everything I've encountered:

The initial pos_bol was wrong, and this was causing a shift of one.

SyntaxError must report the token starting position, not its ending.

We was just not incrementing line number as we do with other expressions.